### PR TITLE
OPEN-93: Rename trusted channel to secure channel

### DIFF
--- a/core-modules-kotlin/sample-app/build.gradle.kts
+++ b/core-modules-kotlin/sample-app/build.gradle.kts
@@ -43,6 +43,6 @@ tasks.test {
 }
 
 application {
-    mainClass = "de.gematik.openhealth.sample.TrustedChannelCliKt"
+    mainClass = "de.gematik.openhealth.sample.SecureChannelCliKt"
     applicationDefaultJvmArgs += listOf("--add-modules=java.smartcardio")
 }

--- a/core-modules-kotlin/sample-app/src/main/kotlin/de/gematik/openhealth/sample/SecureChannelCli.kt
+++ b/core-modules-kotlin/sample-app/src/main/kotlin/de/gematik/openhealth/sample/SecureChannelCli.kt
@@ -24,15 +24,15 @@ package de.gematik.openhealth.sample
 import de.gematik.openhealth.healthcard.ApduException
 import de.gematik.openhealth.healthcard.CardAccessNumber
 import de.gematik.openhealth.healthcard.CommandApdu
-import de.gematik.openhealth.healthcard.TrustedChannelException
-import de.gematik.openhealth.healthcard.establishTrustedChannel
+import de.gematik.openhealth.healthcard.SecureChannelException
+import de.gematik.openhealth.healthcard.establishSecureChannel
 import javax.smartcardio.Card
 import javax.smartcardio.CardTerminals
 import javax.smartcardio.TerminalFactory
 import kotlin.collections.joinToString
 
 /**
- * Minimal demonstration that wires the trusted channel implementation into the PC/SC stack.
+ * Minimal demonstration that wires the secure channel implementation into the PC/SC stack.
  *
  * You need to provide the card access number via the `CARD_ACCESS_NUMBER` environment variable
  * (or the `-DcardAccessNumber=...` JVM property).
@@ -44,22 +44,22 @@ fun main() {
     val apdu = byteArrayOf(0x00, 0x84.toByte(), 0x00, 0x00, 0x08) // GET CHALLENGE default
     val can = try {
         CardAccessNumber.fromDigits(cardAccessNumber)
-    } catch (ex: TrustedChannelException) {
+    } catch (ex: SecureChannelException) {
         error("Invalid CAN: ${ex.message}")
     }
 
     val card = openPcscCard()
     try {
-        val trustedChannel = establishTrustedChannel(PcscCardChannel(card.basicChannel), can)
-        println("Trusted channel established.")
+        val secureChannel = establishSecureChannel(PcscCardChannel(card.basicChannel), can)
+        println("Secure channel established.")
         val command = try {
             CommandApdu.fromBytes(apdu)
         } catch (ex: ApduException) {
             error("Failed to build command APDU: ${ex.message}")
         }
-        val response = trustedChannel.transmit(command)
+        val response = secureChannel.transmit(command)
         val sw = "%04X".format(response.sw.toInt())
-        println("Trusted channel response: SW=$sw, data=${response.data.toHexString()}, status=${response.status}")
+        println("Secure channel response: SW=$sw, data=${response.data.toHexString()}, status=${response.status}")
     } finally {
         try {
             card.disconnect(false)

--- a/core-modules/healthcard/src/exchange/mod.rs
+++ b/core-modules/healthcard/src/exchange/mod.rs
@@ -30,7 +30,7 @@ pub mod read_vsd;
 pub mod sign_challenge;
 #[cfg(test)]
 pub(crate) mod test_utils;
-pub mod trusted_channel;
+pub mod secure_channel;
 
 pub use certificate::retrieve_certificate;
 pub use error::ExchangeError;
@@ -38,6 +38,6 @@ pub use pin::{unlock_egk, verify_pin, HealthCardVerifyPinResult, UnlockMethod};
 pub use random::get_random;
 pub use read_vsd::read_vsd;
 pub use sign_challenge::sign_challenge;
-pub use trusted_channel::{
-    establish_trusted_channel, establish_trusted_channel_with, CardAccessNumber, TrustedChannel,
+pub use secure_channel::{
+    establish_secure_channel, establish_secure_channel_with, CardAccessNumber, SecureChannel,
 };

--- a/core-modules/healthcard/src/ffi/mod.rs
+++ b/core-modules/healthcard/src/ffi/mod.rs
@@ -20,4 +20,4 @@
 // find details in the "Readme" file.
 
 mod channel;
-mod trusted_channel;
+mod secure_channel;


### PR DESCRIPTION
This renames the trusted channel to secure channel to align with the actual PACE protocol.