### PR TITLE
OPEN-00: Move `Package.swift` to repository root and update paths

### DIFF
--- a/.github/workflows/bindings-release.yml
+++ b/.github/workflows/bindings-release.yml
@@ -328,14 +328,14 @@ jobs:
           REPO_URL="https://github.com/${{ github.repository }}/releases/download/${VERSION}/OpenHealthHealthcardFFI.xcframework.zip"
           
           # Update Package.swift to use remote binary target
-          sed -i "s|path: \"./OpenHealthHealthcardFFI.xcframework\"|url: \"$REPO_URL\", checksum: \"$CHECKSUM\"|" core-modules-swift/healthcard/Package.swift
+          sed -i "s|path: \"core-modules-swift/healthcard/OpenHealthHealthcardFFI.xcframework\"|url: \"$REPO_URL\", checksum: \"$CHECKSUM\"|" Package.swift
           
           # Verify change
-          cat core-modules-swift/healthcard/Package.swift
+          cat Package.swift
 
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git add core-modules-swift/healthcard/Package.swift
+          git add Package.swift
           git commit -m "Release ${VERSION}"
           git tag "${VERSION}"
           git push origin "${VERSION}"

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version: 5.9
 // SPDX-FileCopyrightText: Copyright 2025 - 2026 gematik GmbH
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -33,12 +34,12 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "OpenHealthHealthcardFFI",
-            path: "./OpenHealthHealthcardFFI.xcframework"
+            path: "core-modules-swift/healthcard/OpenHealthHealthcardFFI.xcframework"
         ),
         .target(
             name: "OpenHealthHealthcard",
             dependencies: ["OpenHealthHealthcardFFI"],
-            path: "Sources/OpenHealthHealthcard"
+            path: "core-modules-swift/healthcard/Sources/OpenHealthHealthcard"
         ),
     ]
 )

--- a/core-modules-swift/healthcard/README.md
+++ b/core-modules-swift/healthcard/README.md
@@ -42,7 +42,7 @@ This generates:
 
 After building, you can consume this as a Swift Package via:
 
-- `core-modules-swift/healthcard/Package.swift`
+- the repository root `Package.swift`
 
 Notes:
 


### PR DESCRIPTION
- Relocated `Package.swift` to the root of the repository.
- Updated workflows and documentation to reflect the new file path.
