### PR TITLE
OPEN-00: Update version handling in build scripts and workflows

### DIFF
--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -294,6 +294,9 @@ jobs:
 
       - name: Publish Kotlin bindings to mavenLocal (assembled outputs)
         run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            export ORG_GRADLE_PROJECT_version="${{ inputs.version }}"
+          fi
           just kotlin-publish-local
 
       - name: Stage Maven local artifacts for upload

--- a/core-modules-kotlin/build.gradle.kts
+++ b/core-modules-kotlin/build.gradle.kts
@@ -27,7 +27,6 @@ plugins {
 }
 
 group = "de.gematik.openhealth"
-version = "0.1.0-SNAPSHOT"
 
 allprojects {
     repositories {

--- a/core-modules-kotlin/gradle.properties
+++ b/core-modules-kotlin/gradle.properties
@@ -20,3 +20,4 @@
 # find details in the "Readme" file.
 
 kotlin.code.style=official
+version=0.1.0-SNAPSHOT

--- a/core-modules-kotlin/healthcard/build.gradle.kts
+++ b/core-modules-kotlin/healthcard/build.gradle.kts
@@ -30,7 +30,6 @@ plugins {
 }
 
 group = "de.gematik.openhealth"
-version = "0.1.0"
 
 // Location where UniFFI drops generated Kotlin code and native libs (defaults to src/jvmMain to match local workflows).
 val generatedOutRoot: Provider<String> = providers.environmentVariable("OUT_ROOT")


### PR DESCRIPTION
- Move `version` property from build scripts to `gradle.properties`.
- Use `ORG_GRADLE_PROJECT_version` in workflows to dynamically set versions.