### PR TITLE
OPEN-106: Handle PIN warning count 0 in retry mapping

### DIFF
--- a/core-modules/healthcard/src/exchange/pin.rs
+++ b/core-modules/healthcard/src/exchange/pin.rs
@@ -89,6 +89,7 @@ fn map_verify_response(response: HealthCardResponse) -> Result<HealthCardVerifyP
 fn wrong_secret_retries(status: HealthCardResponseStatus) -> Option<u8> {
     use HealthCardResponseStatus::*;
     match status {
+        WrongSecretWarningCount00 => Some(0),
         WrongSecretWarningCount01 => Some(1),
         WrongSecretWarningCount02 => Some(2),
         WrongSecretWarningCount03 => Some(3),


### PR DESCRIPTION
Handle PIN warning count 0 in retry mapping 
