### PR TITLE
OPEN-79: Support for zeroizing Asn1Encoder/WriterScope via VecOfU8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,6 @@ dependencies = [
 name = "asn1"
 version = "0.1.0"
 dependencies = [
- "either",
  "regex",
  "thiserror",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,8 +122,10 @@ dependencies = [
 name = "asn1"
 version = "0.1.0"
 dependencies = [
+ "either",
  "regex",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]

--- a/core-modules-kotlin/healthcard-testkit/src/androidMain/kotlin/de/gematik/openhealth/healthcard/replay/ReplayHarnessAndroid.kt
+++ b/core-modules-kotlin/healthcard-testkit/src/androidMain/kotlin/de/gematik/openhealth/healthcard/replay/ReplayHarnessAndroid.kt
@@ -40,7 +40,10 @@ actual fun establishReplaySecureChannel(transcript: Transcript): SecureChannelHa
 
         override fun transmit(command: CommandApdu): ResponseApdu {
             val responseBytes = try {
-                replayCore.transmit(command.toBytes())
+                val commandBytes = command.toVec()
+                commandBytes.use { commandBytes ->
+                    replayCore.transmit(commandBytes.cloneAsNonzeroizingVec())
+                }
             } catch (ex: RuntimeException) {
                 throw CardChannelException.Transport(code = 0u, reason = ex.message ?: "replay failed")
             }

--- a/core-modules-kotlin/healthcard-testkit/src/jvmMain/kotlin/de/gematik/openhealth/healthcard/replay/ReplayHarnessJvm.kt
+++ b/core-modules-kotlin/healthcard-testkit/src/jvmMain/kotlin/de/gematik/openhealth/healthcard/replay/ReplayHarnessJvm.kt
@@ -40,7 +40,10 @@ actual fun establishReplaySecureChannel(transcript: Transcript): SecureChannelHa
 
         override fun transmit(command: CommandApdu): ResponseApdu {
             val responseBytes = try {
-                replayCore.transmit(command.toBytes())
+                val commandBytes = command.toVec()
+                commandBytes.use { commandBytes ->
+                    replayCore.transmit(commandBytes.cloneAsNonzeroizingVec())
+                }
             } catch (ex: RuntimeException) {
                 throw CardChannelException.Transport(code = 0u, reason = ex.message ?: "replay failed")
             }

--- a/core-modules-kotlin/healthcard/build.gradle.kts
+++ b/core-modules-kotlin/healthcard/build.gradle.kts
@@ -95,6 +95,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
     sourceSets["main"].jniLibs.srcDir(generatedJniLibsDir)
+    lint {
+        // UniFFI generates Android/JVM shared sources under build/, which may legitimately use
+        // APIs that lint can't safely reason about for all Android API levels.
+        checkGeneratedSources = false
+        disable += "NewApi"
+    }
     publishing {
         singleVariant("release") {
             withSourcesJar()

--- a/core-modules-kotlin/sample-app/src/main/kotlin/de/gematik/openhealth/sample/PcscCardChannel.kt
+++ b/core-modules-kotlin/sample-app/src/main/kotlin/de/gematik/openhealth/sample/PcscCardChannel.kt
@@ -45,7 +45,10 @@ class PcscCardChannel(
 
     override fun transmit(command: CommandApdu): ResponseApdu {
         try {
-            val response = delegate.transmit(CommandAPDU(command.toBytes()))
+            val commandBytes = command.toVec()
+            val response = commandBytes.use { commandBytes ->
+                delegate.transmit(CommandAPDU(commandBytes.cloneAsNonzeroizingVec()))
+            }
             return try {
                 ResponseApdu.fromBytes(response.bytes)
             } catch (ex: ApduException) {

--- a/core-modules-swift/healthcard/Tests/OpenHealthHealthcardTests/ExchangeReplayTests.swift
+++ b/core-modules-swift/healthcard/Tests/OpenHealthHealthcardTests/ExchangeReplayTests.swift
@@ -110,7 +110,7 @@ private final class ReplayCardChannel: CardChannel, @unchecked Sendable {
 
     func transmit(command: CommandApdu) throws -> ResponseApdu {
         do {
-            let responseBytes = try core.transmit(commandBytes: command.toBytes())
+            let responseBytes = try core.transmit(commandBytes: command.toVec().cloneAsNonzeroizingVec())
             return try ResponseApdu.fromBytes(bytes: responseBytes)
         } catch let apduError as ApduError {
             throw CardChannelError.Apdu(error: apduError)

--- a/core-modules/asn1/Cargo.toml
+++ b/core-modules/asn1/Cargo.toml
@@ -32,5 +32,3 @@ default = []
 regex = "1.12.2"
 thiserror = "2.0"
 zeroize = { version = "1.8.1", features = ["zeroize_derive"] }
-either = "1.15.0"
-

--- a/core-modules/asn1/Cargo.toml
+++ b/core-modules/asn1/Cargo.toml
@@ -31,3 +31,6 @@ default = []
 [dependencies]
 regex = "1.12.2"
 thiserror = "2.0"
+zeroize = { version = "1.8.1", features = ["zeroize_derive"] }
+either = "1.15.0"
+

--- a/core-modules/asn1/src/cv_certificate.rs
+++ b/core-modules/asn1/src/cv_certificate.rs
@@ -299,7 +299,7 @@ fn parse_date_bytes(bytes: &[u8]) -> Result<CertificateDate, Asn1DecoderError> {
 mod tests {
     use super::*;
     use crate::encoder::Asn1Encoder;
-    use crate::maybe_zeroing_vec::VecOfU8;
+    use crate::maybe_zeroizing_vec::VecOfU8;
     use crate::tag::TagNumberExt;
 
     type EncResult = Result<(), crate::error::Asn1EncoderError>;

--- a/core-modules/asn1/src/cv_certificate.rs
+++ b/core-modules/asn1/src/cv_certificate.rs
@@ -304,7 +304,7 @@ mod tests {
     type EncResult = Result<(), crate::error::Asn1EncoderError>;
 
     fn build_test_certificate(with_extensions: bool) -> Vec<u8> {
-        Asn1Encoder::write::<crate::error::Asn1EncoderError>(|w| {
+        Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {
                     body.write_tagged_object(TAG_PROFILE_IDENTIFIER.application_tag(), |field| -> EncResult {
@@ -413,7 +413,7 @@ mod tests {
         expiration: &[u8],
         signature: &[u8],
     ) -> Vec<u8> {
-        Asn1Encoder::write::<crate::error::Asn1EncoderError>(|w| {
+        Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {
                     body.write_tagged_object(TAG_PROFILE_IDENTIFIER.application_tag(), |field| -> EncResult {
@@ -473,7 +473,7 @@ mod tests {
     }
 
     fn build_certificate_with_chat_data(chat_data: &[u8]) -> Vec<u8> {
-        Asn1Encoder::write::<crate::error::Asn1EncoderError>(|w| {
+        Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {
                     body.write_tagged_object(TAG_PROFILE_IDENTIFIER.application_tag(), |field| -> EncResult {
@@ -533,7 +533,7 @@ mod tests {
     }
 
     fn build_certificate_with_public_key(public_key: &[u8]) -> Vec<u8> {
-        Asn1Encoder::write::<crate::error::Asn1EncoderError>(|w| {
+        Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {
                     body.write_tagged_object(TAG_PROFILE_IDENTIFIER.application_tag(), |field| -> EncResult {

--- a/core-modules/asn1/src/cv_certificate.rs
+++ b/core-modules/asn1/src/cv_certificate.rs
@@ -299,11 +299,12 @@ fn parse_date_bytes(bytes: &[u8]) -> Result<CertificateDate, Asn1DecoderError> {
 mod tests {
     use super::*;
     use crate::encoder::Asn1Encoder;
+    use crate::maybe_zeroing_vec::VecOfU8;
     use crate::tag::TagNumberExt;
 
     type EncResult = Result<(), crate::error::Asn1EncoderError>;
 
-    fn build_test_certificate(with_extensions: bool) -> Vec<u8> {
+    fn build_test_certificate(with_extensions: bool) -> VecOfU8 {
         Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {
@@ -401,7 +402,7 @@ mod tests {
         chr: &[u8],
         effective: &[u8],
         expiration: &[u8],
-    ) -> Vec<u8> {
+    ) -> VecOfU8 {
         build_certificate_with_fields_and_signature(profile_bytes, car, chr, effective, expiration, &[0x00])
     }
 
@@ -412,7 +413,7 @@ mod tests {
         effective: &[u8],
         expiration: &[u8],
         signature: &[u8],
-    ) -> Vec<u8> {
+    ) -> VecOfU8 {
         Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {
@@ -472,7 +473,7 @@ mod tests {
         .expect("encoding must succeed")
     }
 
-    fn build_certificate_with_chat_data(chat_data: &[u8]) -> Vec<u8> {
+    fn build_certificate_with_chat_data(chat_data: &[u8]) -> VecOfU8 {
         Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {
@@ -532,7 +533,7 @@ mod tests {
         .expect("encoding must succeed")
     }
 
-    fn build_certificate_with_public_key(public_key: &[u8]) -> Vec<u8> {
+    fn build_certificate_with_public_key(public_key: &[u8]) -> VecOfU8 {
         Asn1Encoder::write_nonzeroizing::<crate::error::Asn1EncoderError>(|w| {
             w.write_tagged_object(TAG_CV_CERTIFICATE.application_tag().constructed(), |cert| -> EncResult {
                 cert.write_tagged_object(TAG_CERTIFICATE_BODY.application_tag().constructed(), |body| -> EncResult {

--- a/core-modules/asn1/src/date_time.rs
+++ b/core-modules/asn1/src/date_time.rs
@@ -524,7 +524,7 @@ mod tests {
     #[test]
     fn write_utc_time_basic_z() {
         let value = Asn1Time::Utc(Asn1UtcTime::new(2025, 1, 1, 12, 0, None, None).unwrap());
-        let out = crate::encoder::Asn1Encoder::write(|w| -> Result<(), Asn1EncoderError> {
+        let out = crate::encoder::Asn1Encoder::write_nonzeroizing(|w| -> Result<(), Asn1EncoderError> {
             w.write_utc_time(&value)?;
             Ok(())
         })
@@ -542,7 +542,7 @@ mod tests {
         let value = Asn1Time::Utc(
             Asn1UtcTime::new(1999, 12, 31, 23, 59, Some(58), Some(Asn1Offset::utc_offset(2, 30).unwrap())).unwrap(),
         );
-        let out = crate::encoder::Asn1Encoder::write(|w| -> Result<(), Asn1EncoderError> {
+        let out = crate::encoder::Asn1Encoder::write_nonzeroizing(|w| -> Result<(), Asn1EncoderError> {
             w.write_utc_time(&value)?;
             Ok(())
         })
@@ -605,7 +605,7 @@ mod tests {
             )
             .unwrap(),
         );
-        let out = crate::encoder::Asn1Encoder::write(|w| -> Result<(), Asn1EncoderError> {
+        let out = crate::encoder::Asn1Encoder::write_nonzeroizing(|w| -> Result<(), Asn1EncoderError> {
             w.write_generalized_time(&value)?;
             Ok(())
         })
@@ -721,14 +721,14 @@ mod tests {
         let utc = Asn1Time::utc(2024, 1, 1, 0, 0, None, None).unwrap();
         let gen = Asn1Time::generalized(2024, 1, 1, 0, None, None, None, None).unwrap();
 
-        let err = crate::encoder::Asn1Encoder::write(|w| w.write_generalized_time(&utc)).unwrap_err();
+        let err = crate::encoder::Asn1Encoder::write_nonzeroizing(|w| w.write_generalized_time(&utc)).unwrap_err();
         assert!(matches!(
             err,
             Asn1EncoderError::TimeTypeMismatch { expected, actual }
                 if expected == crate::error::Asn1TimeType::Generalized && actual == crate::error::Asn1TimeType::Utc
         ));
 
-        let err = crate::encoder::Asn1Encoder::write(|w| w.write_utc_time(&gen)).unwrap_err();
+        let err = crate::encoder::Asn1Encoder::write_nonzeroizing(|w| w.write_utc_time(&gen)).unwrap_err();
         assert!(matches!(
             err,
             Asn1EncoderError::TimeTypeMismatch { expected, actual }
@@ -739,7 +739,7 @@ mod tests {
     #[test]
     fn write_generalized_time_without_optional_parts() {
         let value = Asn1Time::generalized(2024, 6, 15, 8, None, None, None, None).unwrap();
-        let out = crate::encoder::Asn1Encoder::write(|w| -> Result<(), Asn1EncoderError> {
+        let out = crate::encoder::Asn1Encoder::write_nonzeroizing(|w| -> Result<(), Asn1EncoderError> {
             w.write_generalized_time(&value)?;
             Ok(())
         })

--- a/core-modules/asn1/src/encoder.rs
+++ b/core-modules/asn1/src/encoder.rs
@@ -19,28 +19,99 @@
 // For additional notes and disclaimer from gematik and in case of changes by gematik,
 // find details in the "Readme" file.
 
+use std::ops::{Deref, DerefMut};
+use either::Either;
 use crate::error::Asn1EncoderError;
 use crate::oid::ObjectIdentifier;
 use crate::tag::{Asn1Class, Asn1Form, Asn1Id, UniversalTag};
+use zeroize::ZeroizeOnDrop;
 
 /// ASN.1 encoder for encoding data in ASN.1 format.
 pub struct Asn1Encoder;
 
-/// Scope for writing ASN.1 encoded data. (Top-level, not nested)
-pub struct WriterScope {
-    // TODO: support zeroizing vec
-    buffer: Vec<u8>,
+#[derive(ZeroizeOnDrop, Default)]
+pub struct ZeroizingVecOfU8 {
+    vec: Vec<u8>,
 }
 
-impl Default for WriterScope {
-    fn default() -> Self {
-        Self::new()
+pub trait MaybeZeroizingBuffer: Deref<Target = [u8]> + DerefMut {
+    fn is_zeroizing(&self) -> bool;
+    fn push(&mut self, byte: u8);
+    fn extend_from_slice(&mut self, bytes: &[u8]);
+    fn as_slice(&self) -> &[u8];
+    fn to_concrete_type(self: Box<Self>) -> Either<Vec<u8>, ZeroizingVecOfU8>;
+}
+
+impl Deref for ZeroizingVecOfU8 {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.vec
     }
 }
 
+impl DerefMut for ZeroizingVecOfU8 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vec
+    }
+}
+
+impl MaybeZeroizingBuffer for ZeroizingVecOfU8 {
+    fn is_zeroizing(&self) -> bool {
+        true
+    }
+
+    fn push(&mut self, byte: u8) {
+        self.vec.push(byte);
+    }
+
+    fn extend_from_slice(&mut self, bytes: &[u8]) {
+        self.vec.extend_from_slice(bytes);
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self
+    }
+
+    fn to_concrete_type(self: Box<Self>) -> Either<Vec<u8>, ZeroizingVecOfU8> {
+        Either::Right(*self)
+    }
+}
+
+impl MaybeZeroizingBuffer for Vec<u8> {
+    fn is_zeroizing(&self) -> bool {
+        false
+    }
+
+    fn push(&mut self, byte: u8) {
+        self.push(byte);
+    }
+
+    fn extend_from_slice(&mut self, bytes: &[u8]) {
+        self.extend_from_slice(bytes);
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self
+    }
+
+    fn to_concrete_type(self: Box<Self>) -> Either<Vec<u8>, ZeroizingVecOfU8> {
+        Either::Left(*self)
+    }
+}
+
+/// Scope for writing ASN.1 encoded data. (Top-level, not nested)
+pub struct WriterScope
+{
+    buffer: Box<dyn MaybeZeroizingBuffer>,
+}
+
 impl WriterScope {
-    pub fn new() -> Self {
-        Self { buffer: Vec::new() }
+    pub fn new_with_nonzeroizing_buffer() -> Self {
+        Self { buffer: Box::new(Vec::<u8>::new()) }
+    }
+
+    pub fn new_with_zeroizing_buffer() -> Self {
+        Self { buffer: Box::new(ZeroizingVecOfU8::default()) }
     }
 
     pub fn buffer(&self) -> &[u8] {
@@ -50,13 +121,13 @@ impl WriterScope {
     /// Appends a byte to the buffer.
     #[inline]
     pub fn write_byte(&mut self, byte: u8) {
-        self.buffer.push(byte);
+        self.buffer.as_mut().push(byte);
     }
 
     /// Appends a byte array to the buffer.
     #[inline]
     pub fn write_bytes(&mut self, bytes: &[u8]) {
-        self.buffer.extend_from_slice(bytes);
+        self.buffer.as_mut().extend_from_slice(bytes);
     }
 
     /// Writes an integer in big-endian format, using a variable-length encoding.
@@ -143,7 +214,11 @@ impl WriterScope {
         // tag
         self.write_tag(id.number, id.class, id.form);
         // scope
-        let mut scope = WriterScope::new();
+        let mut scope = if self.buffer.is_zeroizing() {
+            WriterScope::new_with_zeroizing_buffer()
+        } else {
+            WriterScope::new_with_nonzeroizing_buffer()
+        };
         block(&mut scope)?;
         // length + value
         self.write_scope(&scope);
@@ -248,15 +323,30 @@ impl WriterScope {
 
 impl Asn1Encoder {
     /// Encodes the given block of code and returns the resulting byte array.
-    pub fn write<E>(block: impl FnOnce(&mut WriterScope) -> Result<(), E>) -> Result<Vec<u8>, E>
+    pub fn write_nonzeroizing<E>(
+        block: impl FnOnce(&mut WriterScope) -> Result<(), E>
+    ) -> Result<Vec<u8>, E>
     where
         E: From<Asn1EncoderError>,
     {
-        let mut scope = WriterScope::new();
+        let mut scope = WriterScope::new_with_nonzeroizing_buffer();
         block(&mut scope)?;
-        Ok(scope.buffer)
+        Ok(scope.buffer.to_concrete_type().left().expect("since a nonzeroizing buffer is used, to_concrete_type was expected to provide a Vec<u8>"))
+    }
+
+    /// Encodes the given block of code and returns the resulting ZeroizingVecOfU8.
+    pub fn write_zeroizing<E>(
+        block: impl FnOnce(&mut WriterScope) -> Result<(), E>
+    ) -> Result<ZeroizingVecOfU8, E>
+    where
+        E: From<Asn1EncoderError>,
+    {
+        let mut scope = WriterScope::new_with_zeroizing_buffer();
+        block(&mut scope)?;
+        Ok(scope.buffer.to_concrete_type().right().expect("since a zeroizing buffer is used, to_concrete_type was expected to provide a ZeroizingVecOfU8"))
     }
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -277,7 +367,7 @@ mod tests {
 
     #[test]
     fn write_multi_byte_tag_small_value() {
-        let result = Asn1Encoder::write(|w| {
+        let result = Asn1Encoder::write_nonzeroizing(|w| {
             w.write_tagged_object(33u8.application_tag(), |inner| -> Result<(), Asn1EncoderError> {
                 inner.write_byte(0x05);
                 Ok(())
@@ -289,7 +379,7 @@ mod tests {
 
     #[test]
     fn write_multi_byte_tag_larger_value() {
-        let result = Asn1Encoder::write(|w| {
+        let result = Asn1Encoder::write_nonzeroizing(|w| {
             w.write_tagged_object(128u32.application_tag(), |inner| -> Result<(), Asn1EncoderError> {
                 inner.write_byte(0x05);
                 Ok(())
@@ -301,7 +391,7 @@ mod tests {
 
     #[test]
     fn write_multi_byte_tag_max_single_byte() {
-        let result = Asn1Encoder::write::<Asn1EncoderError>(|w| {
+        let result = Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|w| {
             w.write_tagged_object(30u8.application_tag(), |inner| {
                 inner.write_byte(0x05);
                 Ok(())
@@ -313,7 +403,7 @@ mod tests {
 
     #[test]
     fn write_multi_byte_length() {
-        let result = Asn1Encoder::write::<Asn1EncoderError>(|w| {
+        let result = Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|w| {
             w.write_length(123_456_789u64);
             Ok(())
         })
@@ -323,66 +413,66 @@ mod tests {
 
     #[test]
     fn write_base128_encodes_expected() {
-        let mut single = WriterScope::new();
+        let mut single = WriterScope::new_with_nonzeroizing_buffer();
         single.write_base128(0x7F);
         assert_eq!(single.buffer(), &[0x7F]);
 
-        let mut multi = WriterScope::new();
+        let mut multi = WriterScope::new_with_nonzeroizing_buffer();
         multi.write_base128(0x80);
         assert_eq!(multi.buffer(), &[0x81, 0x00]);
     }
 
     #[test]
     fn write_int_expected() {
-        let result = Asn1Encoder::write(|w| w.write_asn1_int(123_456)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_int(123_456)).unwrap();
         assert_eq!(hex(&result), "02 03 01 E2 40");
     }
 
     #[test]
     fn write_int_zero() {
-        let result = Asn1Encoder::write(|w| w.write_asn1_int(0)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_int(0)).unwrap();
         assert_eq!(hex(&result), "02 01 00");
     }
 
     #[test]
     fn write_int_negative() {
-        let result = Asn1Encoder::write(|w| w.write_asn1_int(-123)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_int(-123)).unwrap();
         assert_eq!(hex(&result), "02 01 85");
     }
 
     #[test]
     fn write_utf8_string_expected() {
-        let result = Asn1Encoder::write(|w| w.write_asn1_utf8_string("hello")).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_utf8_string("hello")).unwrap();
         assert_eq!(hex(&result), "0C 05 68 65 6C 6C 6F");
     }
 
     #[test]
     fn write_utf8_string_empty() {
-        let result = Asn1Encoder::write(|w| w.write_asn1_utf8_string("")).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_utf8_string("")).unwrap();
         assert_eq!(hex(&result), "0C 00");
     }
 
     #[test]
     fn write_boolean_true() {
-        let result = Asn1Encoder::write(|w| w.write_asn1_boolean(true)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_boolean(true)).unwrap();
         assert_eq!(hex(&result), "01 01 FF");
     }
 
     #[test]
     fn write_boolean_false() {
-        let result = Asn1Encoder::write(|w| w.write_asn1_boolean(false)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_boolean(false)).unwrap();
         assert_eq!(hex(&result), "01 01 00");
     }
 
     #[test]
     fn write_bit_string_invalid_unused_bits() {
-        let err = Asn1Encoder::write(|w| w.write_asn1_bit_string(&[0xFF], 9)).unwrap_err();
+        let err = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_bit_string(&[0xFF], 9)).unwrap_err();
         assert!(matches!(err, Asn1EncoderError::InvalidUnusedBitCount { .. }));
     }
 
     #[test]
     fn write_with_nested_tags() {
-        let result = Asn1Encoder::write(|w| {
+        let result = Asn1Encoder::write_nonzeroizing(|w| {
             // Universal constructed SEQUENCE (0x10 with constructed bit)
             w.write_tagged_object(0x10u8.universal_tag().constructed(), |inner| {
                 inner.write_asn1_int(42)?;
@@ -396,28 +486,28 @@ mod tests {
     #[test]
     fn write_oid_simple() {
         let oid = ObjectIdentifier::parse("1.2.840.113549").unwrap();
-        let result = Asn1Encoder::write(|w| w.write_object_identifier(&oid)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&oid)).unwrap();
         assert_eq!(hex(&result), "06 06 2A 86 48 86 F7 0D");
     }
 
     #[test]
     fn write_oid_single_part_beyond_40() {
         let oid = ObjectIdentifier::parse("2.100.3").unwrap();
-        let result = Asn1Encoder::write(|w| w.write_object_identifier(&oid)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&oid)).unwrap();
         assert_eq!(hex(&result), "06 03 81 34 03");
     }
 
     #[test]
     fn write_oid_long_identifier() {
         let oid = ObjectIdentifier::parse("1.2.3.4.5.265566").unwrap();
-        let result = Asn1Encoder::write(|w| w.write_object_identifier(&oid)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&oid)).unwrap();
         assert_eq!(hex(&result), "06 07 2A 03 04 05 90 9A 5E");
     }
 
     #[test]
     fn write_oid_large_first_component() {
         let oid = ObjectIdentifier::parse("2.999.1").unwrap();
-        let result = Asn1Encoder::write(|w| w.write_object_identifier(&oid)).unwrap();
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&oid)).unwrap();
         assert_eq!(hex(&result), "06 03 88 37 01");
     }
 

--- a/core-modules/asn1/src/encoder.rs
+++ b/core-modules/asn1/src/encoder.rs
@@ -19,99 +19,26 @@
 // For additional notes and disclaimer from gematik and in case of changes by gematik,
 // find details in the "Readme" file.
 
-use std::ops::{Deref, DerefMut};
-use either::Either;
 use crate::error::Asn1EncoderError;
+use crate::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
 use crate::oid::ObjectIdentifier;
 use crate::tag::{Asn1Class, Asn1Form, Asn1Id, UniversalTag};
-use zeroize::ZeroizeOnDrop;
 
 /// ASN.1 encoder for encoding data in ASN.1 format.
 pub struct Asn1Encoder;
 
-#[derive(ZeroizeOnDrop, Default)]
-pub struct ZeroizingVecOfU8 {
-    vec: Vec<u8>,
-}
-
-pub trait MaybeZeroizingBuffer: Deref<Target = [u8]> + DerefMut {
-    fn is_zeroizing(&self) -> bool;
-    fn push(&mut self, byte: u8);
-    fn extend_from_slice(&mut self, bytes: &[u8]);
-    fn as_slice(&self) -> &[u8];
-    fn to_concrete_type(self: Box<Self>) -> Either<Vec<u8>, ZeroizingVecOfU8>;
-}
-
-impl Deref for ZeroizingVecOfU8 {
-    type Target = [u8];
-    fn deref(&self) -> &Self::Target {
-        &self.vec
-    }
-}
-
-impl DerefMut for ZeroizingVecOfU8 {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.vec
-    }
-}
-
-impl MaybeZeroizingBuffer for ZeroizingVecOfU8 {
-    fn is_zeroizing(&self) -> bool {
-        true
-    }
-
-    fn push(&mut self, byte: u8) {
-        self.vec.push(byte);
-    }
-
-    fn extend_from_slice(&mut self, bytes: &[u8]) {
-        self.vec.extend_from_slice(bytes);
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        &self
-    }
-
-    fn to_concrete_type(self: Box<Self>) -> Either<Vec<u8>, ZeroizingVecOfU8> {
-        Either::Right(*self)
-    }
-}
-
-impl MaybeZeroizingBuffer for Vec<u8> {
-    fn is_zeroizing(&self) -> bool {
-        false
-    }
-
-    fn push(&mut self, byte: u8) {
-        self.push(byte);
-    }
-
-    fn extend_from_slice(&mut self, bytes: &[u8]) {
-        self.extend_from_slice(bytes);
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        &self
-    }
-
-    fn to_concrete_type(self: Box<Self>) -> Either<Vec<u8>, ZeroizingVecOfU8> {
-        Either::Left(*self)
-    }
-}
-
 /// Scope for writing ASN.1 encoded data. (Top-level, not nested)
-pub struct WriterScope
-{
-    buffer: Box<dyn MaybeZeroizingBuffer>,
+pub struct WriterScope {
+    buffer: VecOfU8,
 }
 
 impl WriterScope {
     pub fn new_with_nonzeroizing_buffer() -> Self {
-        Self { buffer: Box::new(Vec::<u8>::new()) }
+        Self { buffer: VecOfU8::new_nonzeroizing(Vec::<u8>::new()) }
     }
 
     pub fn new_with_zeroizing_buffer() -> Self {
-        Self { buffer: Box::new(ZeroizingVecOfU8::default()) }
+        Self { buffer: VecOfU8::new_zeroizing(Vec::<u8>::new()) }
     }
 
     pub fn buffer(&self) -> &[u8] {
@@ -121,13 +48,13 @@ impl WriterScope {
     /// Appends a byte to the buffer.
     #[inline]
     pub fn write_byte(&mut self, byte: u8) {
-        self.buffer.as_mut().push(byte);
+        self.buffer.push(byte);
     }
 
     /// Appends a byte array to the buffer.
     #[inline]
     pub fn write_bytes(&mut self, bytes: &[u8]) {
-        self.buffer.as_mut().extend_from_slice(bytes);
+        self.buffer.extend_from_slice(bytes);
     }
 
     /// Writes an integer in big-endian format, using a variable-length encoding.
@@ -214,10 +141,9 @@ impl WriterScope {
         // tag
         self.write_tag(id.number, id.class, id.form);
         // scope
-        let mut scope = if self.buffer.is_zeroizing() {
-            WriterScope::new_with_zeroizing_buffer()
-        } else {
-            WriterScope::new_with_nonzeroizing_buffer()
+        let mut scope = match self.buffer.get_zeroing_option() {
+            ZeroingOption::None => WriterScope::new_with_nonzeroizing_buffer(),
+            ZeroingOption::Zeroes => WriterScope::new_with_zeroizing_buffer(),
         };
         block(&mut scope)?;
         // length + value
@@ -322,31 +248,31 @@ impl WriterScope {
 }
 
 impl Asn1Encoder {
-    /// Encodes the given block of code and returns the resulting byte array.
-    pub fn write_nonzeroizing<E>(
-        block: impl FnOnce(&mut WriterScope) -> Result<(), E>
-    ) -> Result<Vec<u8>, E>
+    /// Encodes the given block of code and returns the resulting VecOfU8::NonZeroizing.
+    pub fn write_nonzeroizing<E>(block: impl FnOnce(&mut WriterScope) -> Result<(), E>) -> Result<VecOfU8, E>
     where
         E: From<Asn1EncoderError>,
     {
-        let mut scope = WriterScope::new_with_nonzeroizing_buffer();
-        block(&mut scope)?;
-        Ok(scope.buffer.to_concrete_type().left().expect("since a nonzeroizing buffer is used, to_concrete_type was expected to provide a Vec<u8>"))
+        Asn1Encoder::write(WriterScope::new_with_nonzeroizing_buffer(), block)
     }
 
-    /// Encodes the given block of code and returns the resulting ZeroizingVecOfU8.
-    pub fn write_zeroizing<E>(
-        block: impl FnOnce(&mut WriterScope) -> Result<(), E>
-    ) -> Result<ZeroizingVecOfU8, E>
+    /// Encodes the given block of code and returns the resulting VecOfU8::Zeroizing.
+    pub fn write_zeroizing<E>(block: impl FnOnce(&mut WriterScope) -> Result<(), E>) -> Result<VecOfU8, E>
     where
         E: From<Asn1EncoderError>,
     {
-        let mut scope = WriterScope::new_with_zeroizing_buffer();
+        Asn1Encoder::write(WriterScope::new_with_zeroizing_buffer(), block)
+    }
+
+    /// Encodes the given block of code and returns the resulting VecOfU8.
+    fn write<E>(mut scope: WriterScope, block: impl FnOnce(&mut WriterScope) -> Result<(), E>) -> Result<VecOfU8, E>
+    where
+        E: From<Asn1EncoderError>,
+    {
         block(&mut scope)?;
-        Ok(scope.buffer.to_concrete_type().right().expect("since a zeroizing buffer is used, to_concrete_type was expected to provide a ZeroizingVecOfU8"))
+        Ok(scope.buffer)
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/core-modules/asn1/src/encoder.rs
+++ b/core-modules/asn1/src/encoder.rs
@@ -20,7 +20,7 @@
 // find details in the "Readme" file.
 
 use crate::error::Asn1EncoderError;
-use crate::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
+use crate::maybe_zeroizing_vec::{VecOfU8, ZeroizingOption};
 use crate::oid::ObjectIdentifier;
 use crate::tag::{Asn1Class, Asn1Form, Asn1Id, UniversalTag};
 
@@ -141,9 +141,9 @@ impl WriterScope {
         // tag
         self.write_tag(id.number, id.class, id.form);
         // scope
-        let mut scope = match self.buffer.get_zeroing_option() {
-            ZeroingOption::None => WriterScope::new_with_nonzeroizing_buffer(),
-            ZeroingOption::Zeroes => WriterScope::new_with_zeroizing_buffer(),
+        let mut scope = match self.buffer.get_zeroizing_option() {
+            ZeroizingOption::None => WriterScope::new_with_nonzeroizing_buffer(),
+            ZeroizingOption::Zeroes => WriterScope::new_with_zeroizing_buffer(),
         };
         block(&mut scope)?;
         // length + value

--- a/core-modules/asn1/src/lib.rs
+++ b/core-modules/asn1/src/lib.rs
@@ -23,6 +23,6 @@ pub mod date_time;
 pub mod decoder;
 pub mod encoder;
 pub mod error;
-pub mod maybe_zeroing_vec;
+pub mod maybe_zeroizing_vec;
 pub mod oid;
 pub mod tag;

--- a/core-modules/asn1/src/maybe_zeroing_vec.rs
+++ b/core-modules/asn1/src/maybe_zeroing_vec.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright 2025 - 2026 gematik GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *******
+//
+// For additional notes and disclaimer from gematik and in case of changes by gematik,
+// find details in the "Readme" file.
+
+use std::ops::Deref;
+use zeroize::Zeroize;
+
+#[derive(Zeroize, Clone, Debug, PartialEq, Eq)]
+pub enum ZeroingOption {
+    None,
+    Zeroes,
+}
+
+#[derive(Zeroize, Clone, Debug, PartialEq, Eq)]
+pub struct VecOfU8 {
+    vec: Vec<u8>,
+    zeroing_option: ZeroingOption,
+}
+
+impl Drop for VecOfU8 {
+    fn drop(&mut self) {
+        if self.zeroing_option == ZeroingOption::Zeroes {
+            self.zeroize();
+        };
+    }
+}
+
+impl VecOfU8 {
+    pub fn new_nonzeroizing<V: Into<Vec<u8>>>(vec: V) -> Self {
+        VecOfU8 { vec: vec.into(), zeroing_option: ZeroingOption::None }
+    }
+
+    pub fn new_zeroizing<V: Into<Vec<u8>>>(vec: V) -> Self {
+        VecOfU8 { vec: vec.into(), zeroing_option: ZeroingOption::Zeroes }
+    }
+
+    pub fn new<V: Into<Vec<u8>>>(vec: V, opt: ZeroingOption) -> Self {
+        VecOfU8 { vec: vec.into(), zeroing_option: opt }
+    }
+
+    pub fn push(&mut self, byte: u8) {
+        self.vec.push(byte);
+    }
+
+    pub fn extend_from_slice(&mut self, bytes: &[u8]) {
+        self.vec.extend_from_slice(bytes);
+    }
+
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.vec.is_empty()
+    }
+
+    pub fn get_zeroing_option(&self) -> ZeroingOption {
+        self.zeroing_option.clone()
+    }
+
+    pub fn set_zeroing(&mut self) {
+        self.zeroing_option = ZeroingOption::Zeroes;
+    }
+}
+
+impl AsRef<[u8]> for VecOfU8 {
+    fn as_ref(&self) -> &[u8] {
+        self.vec.as_ref()
+    }
+}
+
+impl Deref for VecOfU8 {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.vec
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
+
+    #[test]
+    fn test_new_zeroizing() {
+        let vec = vec![0xA0, 0x01, 0x02];
+        let vec_of_u8 = VecOfU8::new_zeroizing(vec.clone());
+
+        assert_eq!(vec_of_u8.as_ref(), vec.as_slice());
+        assert_eq!(vec_of_u8.zeroing_option, ZeroingOption::Zeroes);
+    }
+
+    #[test]
+    fn test_new_nonzeroizing() {
+        let vec = vec![0xA0, 0x01, 0x02];
+        let vec_of_u8 = VecOfU8::new_nonzeroizing(vec.clone());
+
+        assert_eq!(vec_of_u8.as_ref(), vec.as_slice());
+        assert_eq!(vec_of_u8.zeroing_option, ZeroingOption::None);
+    }
+
+    #[test]
+    fn test_set_zeroing() {
+        let vec = vec![0xA0, 0x01, 0x02];
+        let mut vec_of_u8 = VecOfU8::new_nonzeroizing(vec.clone());
+        vec_of_u8.set_zeroing();
+
+        assert_eq!(vec_of_u8.zeroing_option, ZeroingOption::Zeroes);
+    }
+
+    #[test]
+    fn test_len() {
+        assert_eq!(VecOfU8::new_nonzeroizing(vec![0xA0, 0x01, 0x02]).len(), 3);
+        assert_eq!(VecOfU8::new_nonzeroizing(vec![]).len(), 0);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        assert!(!VecOfU8::new_nonzeroizing(vec![0xA0, 0x01, 0x02]).is_empty());
+        assert!(VecOfU8::new_nonzeroizing(vec![]).is_empty());
+    }
+}

--- a/core-modules/asn1/src/maybe_zeroizing_vec.rs
+++ b/core-modules/asn1/src/maybe_zeroizing_vec.rs
@@ -23,7 +23,7 @@ use std::ops::Deref;
 use zeroize::Zeroize;
 
 #[derive(Zeroize, Clone, Debug, PartialEq, Eq)]
-pub enum ZeroingOption {
+pub enum ZeroizingOption {
     None,
     Zeroes,
 }
@@ -31,12 +31,12 @@ pub enum ZeroingOption {
 #[derive(Zeroize, Clone, Debug, PartialEq, Eq)]
 pub struct VecOfU8 {
     vec: Vec<u8>,
-    zeroing_option: ZeroingOption,
+    zeroizing_option: ZeroizingOption,
 }
 
 impl Drop for VecOfU8 {
     fn drop(&mut self) {
-        if self.zeroing_option == ZeroingOption::Zeroes {
+        if self.zeroizing_option == ZeroizingOption::Zeroes {
             self.zeroize();
         };
     }
@@ -44,15 +44,15 @@ impl Drop for VecOfU8 {
 
 impl VecOfU8 {
     pub fn new_nonzeroizing<V: Into<Vec<u8>>>(vec: V) -> Self {
-        VecOfU8 { vec: vec.into(), zeroing_option: ZeroingOption::None }
+        VecOfU8 { vec: vec.into(), zeroizing_option: ZeroizingOption::None }
     }
 
     pub fn new_zeroizing<V: Into<Vec<u8>>>(vec: V) -> Self {
-        VecOfU8 { vec: vec.into(), zeroing_option: ZeroingOption::Zeroes }
+        VecOfU8 { vec: vec.into(), zeroizing_option: ZeroizingOption::Zeroes }
     }
 
-    pub fn new<V: Into<Vec<u8>>>(vec: V, opt: ZeroingOption) -> Self {
-        VecOfU8 { vec: vec.into(), zeroing_option: opt }
+    pub fn new<V: Into<Vec<u8>>>(vec: V, opt: ZeroizingOption) -> Self {
+        VecOfU8 { vec: vec.into(), zeroizing_option: opt }
     }
 
     pub fn push(&mut self, byte: u8) {
@@ -71,12 +71,12 @@ impl VecOfU8 {
         self.vec.is_empty()
     }
 
-    pub fn get_zeroing_option(&self) -> ZeroingOption {
-        self.zeroing_option.clone()
+    pub fn get_zeroizing_option(&self) -> ZeroizingOption {
+        self.zeroizing_option.clone()
     }
 
-    pub fn set_zeroing(&mut self) {
-        self.zeroing_option = ZeroingOption::Zeroes;
+    pub fn set_zeroizing(&mut self) {
+        self.zeroizing_option = ZeroizingOption::Zeroes;
     }
 }
 
@@ -95,7 +95,7 @@ impl Deref for VecOfU8 {
 
 #[cfg(test)]
 mod tests {
-    use crate::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
+    use crate::maybe_zeroizing_vec::{VecOfU8, ZeroizingOption};
 
     #[test]
     fn test_new_zeroizing() {
@@ -103,7 +103,7 @@ mod tests {
         let vec_of_u8 = VecOfU8::new_zeroizing(vec.clone());
 
         assert_eq!(vec_of_u8.as_ref(), vec.as_slice());
-        assert_eq!(vec_of_u8.zeroing_option, ZeroingOption::Zeroes);
+        assert_eq!(vec_of_u8.zeroizing_option, ZeroizingOption::Zeroes);
     }
 
     #[test]
@@ -112,16 +112,16 @@ mod tests {
         let vec_of_u8 = VecOfU8::new_nonzeroizing(vec.clone());
 
         assert_eq!(vec_of_u8.as_ref(), vec.as_slice());
-        assert_eq!(vec_of_u8.zeroing_option, ZeroingOption::None);
+        assert_eq!(vec_of_u8.zeroizing_option, ZeroizingOption::None);
     }
 
     #[test]
-    fn test_set_zeroing() {
+    fn test_set_zeroizing() {
         let vec = vec![0xA0, 0x01, 0x02];
         let mut vec_of_u8 = VecOfU8::new_nonzeroizing(vec.clone());
-        vec_of_u8.set_zeroing();
+        vec_of_u8.set_zeroizing();
 
-        assert_eq!(vec_of_u8.zeroing_option, ZeroingOption::Zeroes);
+        assert_eq!(vec_of_u8.zeroizing_option, ZeroizingOption::Zeroes);
     }
 
     #[test]

--- a/core-modules/asn1/src/oid.rs
+++ b/core-modules/asn1/src/oid.rs
@@ -150,15 +150,15 @@ mod tests {
     #[test]
     fn write_object_identifier_rejects_invalid_components() {
         let missing = ObjectIdentifier(Vec::new());
-        let err = Asn1Encoder::write(|w| w.write_object_identifier(&missing)).unwrap_err();
+        let err = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&missing)).unwrap_err();
         assert!(matches!(err, Asn1EncoderError::ObjectIdentifierMissingComponents));
 
         let invalid_first = ObjectIdentifier(vec![3, 1]);
-        let err = Asn1Encoder::write(|w| w.write_object_identifier(&invalid_first)).unwrap_err();
+        let err = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&invalid_first)).unwrap_err();
         assert!(matches!(err, Asn1EncoderError::InvalidObjectIdentifierFirstComponent { .. }));
 
         let invalid_second = ObjectIdentifier(vec![1, 40]);
-        let err = Asn1Encoder::write(|w| w.write_object_identifier(&invalid_second)).unwrap_err();
+        let err = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&invalid_second)).unwrap_err();
         assert!(matches!(err, Asn1EncoderError::InvalidObjectIdentifierSecondComponent { .. }));
     }
 }

--- a/core-modules/crypto/src/ec/ec_key.rs
+++ b/core-modules/crypto/src/ec/ec_key.rs
@@ -26,6 +26,7 @@ use crate::ossl;
 use asn1::decoder::Asn1Decoder;
 use asn1::encoder::Asn1Encoder;
 use asn1::error::{Asn1DecoderError, Asn1EncoderError};
+use asn1::maybe_zeroing_vec::VecOfU8;
 use asn1::oid::ObjectIdentifier;
 use asn1::tag::UniversalTag;
 use num_bigint::BigInt;
@@ -208,7 +209,7 @@ impl EcPublicKey {
     ///   algorithm         AlgorithmIdentifier,
     ///   subjectPublicKey  BIT STRING
     /// }
-    pub fn encode_to_asn1(&self) -> CryptoResult<Vec<u8>> {
+    pub fn encode_to_asn1(&self) -> CryptoResult<VecOfU8> {
         Asn1Encoder::write_nonzeroizing(|scope| {
             // SEQUENCE (SubjectPublicKeyInfo)
             scope.write_tagged_object(UniversalTag::Sequence.constructed(), |scope| {
@@ -285,7 +286,7 @@ impl EcPrivateKey {
     ///   privateKey PrivateKey,
     ///   attributes [0] IMPLICIT Attributes OPTIONAL
     /// }
-    pub fn encode_to_asn1(&self) -> CryptoResult<Vec<u8>> {
+    pub fn encode_to_asn1(&self) -> CryptoResult<VecOfU8> {
         Asn1Encoder::write_nonzeroizing(|scope| {
             // SEQUENCE (PrivateKeyInfo)
             scope.write_tagged_object(UniversalTag::Sequence.constructed(), |scope| {

--- a/core-modules/crypto/src/ec/ec_key.rs
+++ b/core-modules/crypto/src/ec/ec_key.rs
@@ -209,7 +209,7 @@ impl EcPublicKey {
     ///   subjectPublicKey  BIT STRING
     /// }
     pub fn encode_to_asn1(&self) -> CryptoResult<Vec<u8>> {
-        Asn1Encoder::write(|scope| {
+        Asn1Encoder::write_nonzeroizing(|scope| {
             // SEQUENCE (SubjectPublicKeyInfo)
             scope.write_tagged_object(UniversalTag::Sequence.constructed(), |scope| {
                 // SEQUENCE (AlgorithmIdentifier)
@@ -286,7 +286,7 @@ impl EcPrivateKey {
     ///   attributes [0] IMPLICIT Attributes OPTIONAL
     /// }
     pub fn encode_to_asn1(&self) -> CryptoResult<Vec<u8>> {
-        Asn1Encoder::write(|scope| {
+        Asn1Encoder::write_nonzeroizing(|scope| {
             // SEQUENCE (PrivateKeyInfo)
             scope.write_tagged_object(UniversalTag::Sequence.constructed(), |scope| {
                 // version (INTEGER 0)
@@ -487,7 +487,7 @@ mod tests {
     fn decode_public_key_rejects_unused_bits() {
         let curve = EcCurve::BrainpoolP256r1;
         let key_bytes = sample_pub(curve.clone());
-        let der = Asn1Encoder::write::<Asn1EncoderError>(|scope| -> Result<(), Asn1EncoderError> {
+        let der = Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|scope| -> Result<(), Asn1EncoderError> {
             scope.write_tagged_object(UniversalTag::Sequence.constructed(), |scope| {
                 scope.write_tagged_object::<Asn1EncoderError>(UniversalTag::Sequence.constructed(), |scope| {
                     scope.write_object_identifier(&EcPublicKey::algorithm_oid())?;
@@ -510,7 +510,7 @@ mod tests {
         let curve = EcCurve::BrainpoolP256r1;
         let key_bytes = sample_pub(curve.clone());
         let wrong_oid = ObjectIdentifier::parse("1.2.3.4").unwrap();
-        let der = Asn1Encoder::write::<Asn1EncoderError>(|scope| -> Result<(), Asn1EncoderError> {
+        let der = Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|scope| -> Result<(), Asn1EncoderError> {
             scope.write_tagged_object(UniversalTag::Sequence.constructed(), |scope| {
                 scope.write_tagged_object::<Asn1EncoderError>(UniversalTag::Sequence.constructed(), |scope| {
                     scope.write_object_identifier(&wrong_oid)?;
@@ -533,7 +533,7 @@ mod tests {
     fn decode_private_key_rejects_version() {
         let curve = EcCurve::BrainpoolP256r1;
         let private = sample_priv_bytes(curve.clone());
-        let der = Asn1Encoder::write::<Asn1EncoderError>(|scope| -> Result<(), Asn1EncoderError> {
+        let der = Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|scope| -> Result<(), Asn1EncoderError> {
             scope.write_tagged_object(UniversalTag::Sequence.constructed(), |scope| {
                 scope.write_asn1_int(0)?;
                 scope.write_tagged_object::<Asn1EncoderError>(UniversalTag::Sequence.constructed(), |scope| {

--- a/core-modules/crypto/src/ec/ec_key.rs
+++ b/core-modules/crypto/src/ec/ec_key.rs
@@ -26,7 +26,7 @@ use crate::ossl;
 use asn1::decoder::Asn1Decoder;
 use asn1::encoder::Asn1Encoder;
 use asn1::error::{Asn1DecoderError, Asn1EncoderError};
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 use asn1::oid::ObjectIdentifier;
 use asn1::tag::UniversalTag;
 use num_bigint::BigInt;

--- a/core-modules/healthcard-apdu-tools/src/apdu_tools.rs
+++ b/core-modules/healthcard-apdu-tools/src/apdu_tools.rs
@@ -139,7 +139,7 @@ impl CardChannel for ReplayChannel {
             .session
             .transmit_bytes(&tx)
             .map_err(|err| ExchangeError::Transport { code: 0, message: err.to_string() })?;
-        CardResponseApdu::new_nonzeroing(&rx).map_err(ExchangeError::from)
+        CardResponseApdu::new_nonzeroizing(&rx).map_err(ExchangeError::from)
     }
 }
 
@@ -197,7 +197,7 @@ impl CardChannel for PcscChannel {
             .card
             .transmit(&tx, &mut self.recv_buffer)
             .map_err(|err| ExchangeError::Transport { code: 0, message: format!("pcsc transmit failed: {err}") })?;
-        CardResponseApdu::new_nonzeroing(response).map_err(ExchangeError::from)
+        CardResponseApdu::new_nonzeroizing(response).map_err(ExchangeError::from)
     }
 }
 
@@ -216,7 +216,7 @@ mod tests {
         fn new(responses: Vec<Vec<u8>>) -> Self {
             let responses = responses
                 .into_iter()
-                .map(|raw| CardResponseApdu::new_nonzeroing(&raw).expect("valid response APDU"))
+                .map(|raw| CardResponseApdu::new_nonzeroizing(&raw).expect("valid response APDU"))
                 .collect();
             Self { responses, supports_extended_length: false }
         }

--- a/core-modules/healthcard-apdu-tools/src/apdu_tools.rs
+++ b/core-modules/healthcard-apdu-tools/src/apdu_tools.rs
@@ -247,7 +247,7 @@ mod tests {
         let replay = Transcript::from_jsonl_str(&jsonl).unwrap();
         let mut channel = ReplayChannel::from_transcript(replay);
         let response = channel.transmit(&command).unwrap();
-        assert_eq!(response.to_bytes(), vec![0x90, 0x00]);
+        assert_eq!(response.to_bytes().as_ref(), &vec![0x90, 0x00]);
     }
 
     #[test]

--- a/core-modules/healthcard-apdu-tools/src/apdu_tools.rs
+++ b/core-modules/healthcard-apdu-tools/src/apdu_tools.rs
@@ -68,10 +68,10 @@ where
     }
 
     fn transmit(&mut self, command: &CardCommandApdu) -> Result<CardResponseApdu, Self::Error> {
-        let tx = command.to_bytes();
+        let tx = command.to_vec();
         match self.inner.transmit(command) {
             Ok(response) => {
-                self.transcript.push_exchange(&tx, &response.to_bytes());
+                self.transcript.push_exchange(&tx, &response.to_vec());
                 Ok(response)
             }
             Err(err) => {
@@ -94,10 +94,10 @@ where
     }
 
     fn transmit(&mut self, command: &CardCommandApdu) -> Result<CardResponseApdu, Self::Error> {
-        let tx = command.to_bytes();
+        let tx = command.to_vec();
         match self.inner.transmit(command) {
             Ok(response) => {
-                self.transcript.push_exchange(&tx, &response.to_bytes());
+                self.transcript.push_exchange(&tx, &response.to_vec());
                 Ok(response)
             }
             Err(err) => {
@@ -134,12 +134,12 @@ impl CardChannel for ReplayChannel {
     }
 
     fn transmit(&mut self, command: &CardCommandApdu) -> Result<CardResponseApdu, Self::Error> {
-        let tx = command.to_bytes();
+        let tx = command.to_vec();
         let rx = self
             .session
             .transmit_bytes(&tx)
             .map_err(|err| ExchangeError::Transport { code: 0, message: err.to_string() })?;
-        CardResponseApdu::new(&rx).map_err(ExchangeError::from)
+        CardResponseApdu::new_nonzeroing(&rx).map_err(ExchangeError::from)
     }
 }
 
@@ -192,12 +192,12 @@ impl CardChannel for PcscChannel {
     }
 
     fn transmit(&mut self, command: &CardCommandApdu) -> Result<CardResponseApdu, Self::Error> {
-        let tx = command.to_bytes();
+        let tx = command.to_vec();
         let response = self
             .card
             .transmit(&tx, &mut self.recv_buffer)
             .map_err(|err| ExchangeError::Transport { code: 0, message: format!("pcsc transmit failed: {err}") })?;
-        CardResponseApdu::new(response).map_err(ExchangeError::from)
+        CardResponseApdu::new_nonzeroing(response).map_err(ExchangeError::from)
     }
 }
 
@@ -214,8 +214,10 @@ mod tests {
 
     impl MockSession {
         fn new(responses: Vec<Vec<u8>>) -> Self {
-            let responses =
-                responses.into_iter().map(|raw| CardResponseApdu::new(&raw).expect("valid response APDU")).collect();
+            let responses = responses
+                .into_iter()
+                .map(|raw| CardResponseApdu::new_nonzeroing(&raw).expect("valid response APDU"))
+                .collect();
             Self { responses, supports_extended_length: false }
         }
     }
@@ -247,7 +249,7 @@ mod tests {
         let replay = Transcript::from_jsonl_str(&jsonl).unwrap();
         let mut channel = ReplayChannel::from_transcript(replay);
         let response = channel.transmit(&command).unwrap();
-        assert_eq!(response.to_bytes().as_ref(), &vec![0x90, 0x00]);
+        assert_eq!(response.to_vec().as_ref(), &vec![0x90, 0x00]);
     }
 
     #[test]
@@ -299,13 +301,13 @@ mod tests {
             let channel = PcscChannel::connect(&reader, true).expect("pcsc connect");
             let mut recorder = RecordingChannel::new(channel);
             let response = recorder.execute_command(&HealthCardCommand::select(false, false)).expect("select MF");
-            let response_bytes = response.apdu.to_bytes();
+            let response_bytes = response.apdu.to_vec();
 
             let transcript = recorder.into_transcript();
             let mut replay = ReplayChannel::from_transcript(transcript);
             let replay_response =
                 replay.execute_command(&HealthCardCommand::select(false, false)).expect("replay select MF");
-            assert_eq!(replay_response.apdu.to_bytes(), response_bytes);
+            assert_eq!(replay_response.apdu.to_vec(), response_bytes);
         }
 
         #[test]

--- a/core-modules/healthcard/src/command/apdu.rs
+++ b/core-modules/healthcard/src/command/apdu.rs
@@ -41,7 +41,7 @@ pub enum ApduError {
 /// Common trait for all APDU types
 pub trait Apdu {
     fn bytes(&self) -> &[u8];
-    fn to_bytes(&self) -> VecOfU8;
+    fn to_vec(&self) -> VecOfU8;
 }
 
 /// Encodes the data length (Nc) for extended length APDUs (Lc1, Lc2).
@@ -244,7 +244,7 @@ impl CardCommandApdu {
     }
 
     /// Returns a clone of the APDU byte array.
-    pub fn to_bytes(&self) -> VecOfU8 {
+    pub fn to_vec(&self) -> VecOfU8 {
         self.apdu.clone()
     }
 
@@ -492,7 +492,7 @@ impl Apdu for CardCommandApdu {
         &self.apdu
     }
 
-    fn to_bytes(&self) -> VecOfU8 {
+    fn to_vec(&self) -> VecOfU8 {
         self.apdu.clone()
     }
 }
@@ -519,23 +519,47 @@ pub struct CardResponseApdu {
 }
 
 impl CardResponseApdu {
+    /// Creates a new CardResponseApdu from a byte slice.
+    ///
+    /// # Arguments
+    /// * `apdu` - The raw byte array of the received APDU.
+    pub fn new_nonzeroing(apdu: &[u8]) -> Result<Self, ApduError> {
+        Self::new(apdu, ZeroingOption::None)
+    }
+
     /// Creates a new CardResponseApdu from a byte array.
     ///
     /// # Arguments
     /// * `apdu` - The raw byte array of the received APDU.
-    pub fn new(apdu: &[u8]) -> Result<Self, ApduError> {
+    /// * `zeroing_option` - Whether the bytes should be zeroed out after use.
+    pub fn new(apdu: &[u8], zeroing_option: ZeroingOption) -> Result<Self, ApduError> {
         if apdu.len() < 2 {
             return Err(ApduError::InvalidApdu(
                 "Response APDU must contain at least 2 bytes (status bytes SW1, SW2)".to_string(),
             ));
         }
 
-        Ok(CardResponseApdu { bytes: VecOfU8::new_nonzeroizing(apdu.to_vec()) })
+        Ok(CardResponseApdu { bytes: VecOfU8::new(apdu.to_vec(), zeroing_option) })
+    }
+
+    /// Creates a new CardResponseApdu from a Vec<u8>.
+    ///
+    /// # Arguments
+    /// * `apdu` - A Vec<u8> containing the raw byte array of the received APDU.
+    /// * `zeroing_option` - Whether the bytes should be zeroed out after use.
+    pub fn new_from_vec(apdu: Vec<u8>, zeroing_option: ZeroingOption) -> Result<Self, ApduError> {
+        if apdu.len() < 2 {
+            return Err(ApduError::InvalidApdu(
+                "Response APDU must contain at least 2 bytes (status bytes SW1, SW2)".to_string(),
+            ));
+        }
+
+        Ok(CardResponseApdu { bytes: VecOfU8::new(apdu, zeroing_option) })
     }
 
     /// Convenience constructor mirroring `new`.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ApduError> {
-        Self::new(bytes)
+        Self::new_nonzeroing(bytes)
     }
 
     /// The data bytes of the response.
@@ -573,12 +597,12 @@ impl CardResponseApdu {
     }
 
     /// Returns a clone of the raw byte array.
-    pub fn to_bytes(&self) -> VecOfU8 {
+    pub fn to_vec(&self) -> VecOfU8 {
         self.bytes.clone()
     }
 
     /// Consumes the response and returns the underlying bytes.
-    pub fn into_bytes(self) -> VecOfU8 {
+    pub fn into_vec(self) -> VecOfU8 {
         self.bytes
     }
 }
@@ -588,7 +612,7 @@ impl Apdu for CardResponseApdu {
         &self.bytes
     }
 
-    fn to_bytes(&self) -> VecOfU8 {
+    fn to_vec(&self) -> VecOfU8 {
         self.bytes.clone()
     }
 }
@@ -612,7 +636,7 @@ mod tests {
     fn test_card_command_apdu_case1() {
         // Case 1: Header only
         let apdu = CardCommandApdu::header_only(0x00, 0xA4, 0x04, 0x00).unwrap();
-        assert_eq!(apdu.to_bytes(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00]));
+        assert_eq!(apdu.to_vec(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00]));
         assert_eq!(apdu.data, None);
         assert_eq!(apdu.ne, None);
     }
@@ -621,7 +645,7 @@ mod tests {
     fn test_card_command_apdu_case2s() {
         // Case 2s: Header + Le (short)
         let apdu = CardCommandApdu::with_expect(0x00, 0xA4, 0x04, 0x00, LengthClass::Short, 256).unwrap();
-        assert_eq!(apdu.to_bytes(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00, 0x00]));
+        assert_eq!(apdu.to_vec(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00, 0x00]));
         assert_eq!(apdu.data, None);
         assert_eq!(apdu.ne, Some(256));
     }
@@ -630,7 +654,7 @@ mod tests {
     fn test_card_command_apdu_shape_helpers() {
         // header only
         let header = CardCommandApdu::header_only(0x00, 0xA4, 0x04, 0x00).unwrap();
-        assert_eq!(header.to_bytes(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00]));
+        assert_eq!(header.to_vec(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00]));
 
         // expect short validation
         assert!(CardCommandApdu::with_expect(0, 0, 0, 0, LengthClass::Short, 257).is_err());
@@ -701,7 +725,7 @@ mod tests {
     #[test]
     fn test_card_response_apdu() {
         // Test response APDU with status 9000 (success)
-        let response = CardResponseApdu::new(&[0x01, 0x02, 0x90, 0x00]).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&[0x01, 0x02, 0x90, 0x00]).unwrap();
         assert_eq!(response.to_data(), vec![0x01, 0x02]);
         assert_eq!(response.sw1(), 0x90);
         assert_eq!(response.sw2(), 0x00);
@@ -717,7 +741,7 @@ mod tests {
         assert_eq!(command.p1(), 0x04);
         assert_eq!(command.p2(), 0x00);
         assert_eq!(command.as_data(), Some(&[0x3F, 0x00][..]));
-        assert_eq!(command.to_bytes(), bytes);
+        assert_eq!(command.to_vec(), bytes);
         assert_eq!(command.expected_length(), Some(256));
 
         let response_bytes = [0x6F, 0x12, 0x90, 0x00];
@@ -895,6 +919,6 @@ mod tests {
 
     #[test]
     fn test_response_apdu_requires_status() {
-        assert!(matches!(CardResponseApdu::new(&[0x90]), Err(ApduError::InvalidApdu(_))));
+        assert!(matches!(CardResponseApdu::new_nonzeroing(&[0x90]), Err(ApduError::InvalidApdu(_))));
     }
 }

--- a/core-modules/healthcard/src/command/apdu.rs
+++ b/core-modules/healthcard/src/command/apdu.rs
@@ -19,6 +19,7 @@
 // For additional notes and disclaimer from gematik and in case of changes by gematik,
 // find details in the "Readme" file.
 
+use asn1::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
 use std::fmt;
 use thiserror::Error;
 
@@ -40,7 +41,7 @@ pub enum ApduError {
 /// Common trait for all APDU types
 pub trait Apdu {
     fn bytes(&self) -> &[u8];
-    fn to_bytes(&self) -> Vec<u8>;
+    fn to_bytes(&self) -> VecOfU8;
 }
 
 /// Encodes the data length (Nc) for extended length APDUs (Lc1, Lc2).
@@ -127,12 +128,12 @@ fn encode_expected_length_short(ne: usize) -> Result<[u8; 1], ApduError> {
 
 #[derive(Clone)]
 pub struct CardCommandApdu {
-    apdu: Vec<u8>,
+    apdu: VecOfU8,
     cla: u8,
     ins: u8,
     p1: u8,
     p2: u8,
-    data: Option<Vec<u8>>,
+    data: Option<VecOfU8>,
     ne: Option<usize>,
 }
 
@@ -147,7 +148,7 @@ pub enum LengthClass {
 impl CardCommandApdu {
     /// Construct a case 1 APDU (header only).
     pub fn header_only(cla: u8, ins: u8, p1: u8, p2: u8) -> Result<Self, ApduError> {
-        Self::new(cla, ins, p1, p2, None::<Vec<u8>>, None)
+        Self::new(cla, ins, p1, p2, None::<VecOfU8>, None)
     }
 
     /// Construct a case 2 APDU (Le only) with explicit length class.
@@ -173,19 +174,18 @@ impl CardCommandApdu {
                 }
             }
         }
-        Self::new(cla, ins, p1, p2, None::<Vec<u8>>, Some(ne))
+        Self::new(cla, ins, p1, p2, None::<VecOfU8>, Some(ne))
     }
 
     /// Construct a case 3 APDU (Lc + data) with explicit length class.
-    pub fn with_data<D: Into<Vec<u8>>>(
+    pub fn with_data(
         cla: u8,
         ins: u8,
         p1: u8,
         p2: u8,
         length_class: LengthClass,
-        data: D,
+        data_vec: VecOfU8,
     ) -> Result<Self, ApduError> {
-        let data_vec = data.into();
         match length_class {
             LengthClass::Short => {
                 if data_vec.is_empty() || data_vec.len() >= EXPECTED_LENGTH_WILDCARD_SHORT {
@@ -204,16 +204,15 @@ impl CardCommandApdu {
     }
 
     /// Construct a case 4 APDU (Lc + data + Le) with explicit length class.
-    pub fn with_data_and_expect<D: Into<Vec<u8>>>(
+    pub fn with_data_and_expect(
         cla: u8,
         ins: u8,
         p1: u8,
         p2: u8,
         length_class: LengthClass,
-        data: D,
+        data_vec: VecOfU8,
         ne: usize,
     ) -> Result<Self, ApduError> {
-        let data_vec = data.into();
         match length_class {
             LengthClass::Short => {
                 if data_vec.is_empty() || data_vec.len() >= EXPECTED_LENGTH_WILDCARD_SHORT {
@@ -245,13 +244,8 @@ impl CardCommandApdu {
     }
 
     /// Returns a clone of the APDU byte array.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> VecOfU8 {
         self.apdu.clone()
-    }
-
-    /// Consumes the APDU and returns the underlying bytes.
-    pub fn into_bytes(self) -> Vec<u8> {
-        self.apdu
     }
 
     /// Returns the expected length (Ne) of the response.
@@ -292,7 +286,7 @@ impl CardCommandApdu {
     /// * `p2` - The parameter 2 byte (P2).
     /// * `ne` - The expected response length (Ne), or None for case 1.
     pub fn new_without_data(cla: u8, ins: u8, p1: u8, p2: u8, ne: Option<usize>) -> Result<Self, ApduError> {
-        Self::new(cla, ins, p1, p2, None::<Vec<u8>>, ne)
+        Self::new(cla, ins, p1, p2, None::<VecOfU8>, ne)
     }
 
     /// Creates a CardCommandApdu for cases 1, 2s, 2e, 3s, 3e, 4s, or 4e.
@@ -304,14 +298,7 @@ impl CardCommandApdu {
     /// * `p2` - The parameter 2 byte (P2).
     /// * `data` - The command data (body), or None for cases 1, 2s, or 2e.
     /// * `ne` - The expected response length (Ne), or None for cases 3s or 3e.
-    pub fn new<D: Into<Vec<u8>>>(
-        cla: u8,
-        ins: u8,
-        p1: u8,
-        p2: u8,
-        data: Option<D>,
-        ne: Option<usize>,
-    ) -> Result<Self, ApduError> {
+    pub fn new(cla: u8, ins: u8, p1: u8, p2: u8, data: Option<VecOfU8>, ne: Option<usize>) -> Result<Self, ApduError> {
         // Validate the expected length (Ne), if provided.
         if let Some(ne_val) = ne {
             if ne_val > EXPECTED_LENGTH_WILDCARD_EXTENDED {
@@ -326,8 +313,7 @@ impl CardCommandApdu {
         // Append header: |CLA|INS|P1|P2|
         apdu.extend_from_slice(&[cla, ins, p1, p2]);
 
-        let (_data_length, _data_offset, data_vec) = if let Some(data_into) = data {
-            let data_vec = data_into.into();
+        let (_data_length, _data_offset, data_vec) = if let Some(data_vec) = data {
             let data_length = data_vec.len();
 
             if data_length >= EXPECTED_LENGTH_WILDCARD_EXTENDED {
@@ -388,6 +374,11 @@ impl CardCommandApdu {
             }
         };
 
+        let apdu: VecOfU8 = {
+            let apdu_zeroing_opt = if let Some(d) = &data_vec { d.get_zeroing_option() } else { ZeroingOption::None };
+            VecOfU8::new(apdu, apdu_zeroing_opt)
+        };
+
         Ok(CardCommandApdu { apdu, cla, ins, p1, p2, data: data_vec, ne })
     }
 
@@ -432,7 +423,7 @@ impl CardCommandApdu {
                 return Err(ApduError::InvalidApdu(format!(
                     "Invalid APDU: length={}, lengthIndicator={}",
                     apdu.len(),
-                    (apdu[4] as usize)
+                    apdu[4] as usize
                 )));
             }
 
@@ -447,7 +438,7 @@ impl CardCommandApdu {
                     return Err(ApduError::InvalidApdu(format!(
                         "Invalid APDU: length={}, lengthIndicator={}, extendedLength={}",
                         apdu.len(),
-                        (apdu[4] as usize),
+                        apdu[4] as usize,
                         data_length_extended
                     )));
                 }
@@ -470,7 +461,7 @@ impl CardCommandApdu {
                     return Err(ApduError::InvalidApdu(format!(
                         "Invalid APDU: length={}, lengthIndicator={}, extendedLength={}",
                         apdu.len(),
-                        (apdu[4] as usize),
+                        apdu[4] as usize,
                         data_length_extended
                     )));
                 }
@@ -487,12 +478,12 @@ impl CardCommandApdu {
         let data = if data_length > 0 {
             let start = data_offset;
             let end = start + data_length;
-            Some(apdu[start..end].to_vec())
+            Some(VecOfU8::new_nonzeroizing(apdu[start..end].to_vec()))
         } else {
             None
         };
 
-        Ok(CardCommandApdu { apdu: apdu.to_vec(), cla, ins, p1, p2, data, ne: expected_length })
+        Ok(CardCommandApdu { apdu: VecOfU8::new_nonzeroizing(apdu), cla, ins, p1, p2, data, ne: expected_length })
     }
 }
 
@@ -501,7 +492,7 @@ impl Apdu for CardCommandApdu {
         &self.apdu
     }
 
-    fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> VecOfU8 {
         self.apdu.clone()
     }
 }
@@ -524,7 +515,7 @@ impl fmt::Debug for CardCommandApdu {
 /// as defined by ISO/IEC 7816-4.
 #[derive(Clone, Eq, PartialEq)]
 pub struct CardResponseApdu {
-    bytes: Vec<u8>,
+    bytes: VecOfU8,
 }
 
 impl CardResponseApdu {
@@ -539,7 +530,7 @@ impl CardResponseApdu {
             ));
         }
 
-        Ok(CardResponseApdu { bytes: apdu.to_vec() })
+        Ok(CardResponseApdu { bytes: VecOfU8::new_nonzeroizing(apdu.to_vec()) })
     }
 
     /// Convenience constructor mirroring `new`.
@@ -582,12 +573,12 @@ impl CardResponseApdu {
     }
 
     /// Returns a clone of the raw byte array.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> VecOfU8 {
         self.bytes.clone()
     }
 
     /// Consumes the response and returns the underlying bytes.
-    pub fn into_bytes(self) -> Vec<u8> {
+    pub fn into_bytes(self) -> VecOfU8 {
         self.bytes
     }
 }
@@ -597,7 +588,7 @@ impl Apdu for CardResponseApdu {
         &self.bytes
     }
 
-    fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(&self) -> VecOfU8 {
         self.bytes.clone()
     }
 }
@@ -621,7 +612,7 @@ mod tests {
     fn test_card_command_apdu_case1() {
         // Case 1: Header only
         let apdu = CardCommandApdu::header_only(0x00, 0xA4, 0x04, 0x00).unwrap();
-        assert_eq!(apdu.to_bytes(), vec![0x00, 0xA4, 0x04, 0x00]);
+        assert_eq!(apdu.to_bytes(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00]));
         assert_eq!(apdu.data, None);
         assert_eq!(apdu.ne, None);
     }
@@ -630,7 +621,7 @@ mod tests {
     fn test_card_command_apdu_case2s() {
         // Case 2s: Header + Le (short)
         let apdu = CardCommandApdu::with_expect(0x00, 0xA4, 0x04, 0x00, LengthClass::Short, 256).unwrap();
-        assert_eq!(apdu.to_bytes(), vec![0x00, 0xA4, 0x04, 0x00, 0x00]);
+        assert_eq!(apdu.to_bytes(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00, 0x00]));
         assert_eq!(apdu.data, None);
         assert_eq!(apdu.ne, Some(256));
     }
@@ -639,7 +630,7 @@ mod tests {
     fn test_card_command_apdu_shape_helpers() {
         // header only
         let header = CardCommandApdu::header_only(0x00, 0xA4, 0x04, 0x00).unwrap();
-        assert_eq!(header.to_bytes(), vec![0x00, 0xA4, 0x04, 0x00]);
+        assert_eq!(header.to_bytes(), VecOfU8::new_nonzeroizing(vec![0x00, 0xA4, 0x04, 0x00]));
 
         // expect short validation
         assert!(CardCommandApdu::with_expect(0, 0, 0, 0, LengthClass::Short, 257).is_err());
@@ -648,20 +639,62 @@ mod tests {
 
         // data extended validation
         let long_data = vec![0u8; EXPECTED_LENGTH_WILDCARD_SHORT];
-        let case3e = CardCommandApdu::with_data(0x80, 0x10, 0, 0, LengthClass::Extended, long_data.clone()).unwrap();
+        let case3e = CardCommandApdu::with_data(
+            0x80,
+            0x10,
+            0,
+            0,
+            LengthClass::Extended,
+            VecOfU8::new_nonzeroizing(long_data.clone()),
+        )
+        .unwrap();
         assert_eq!(case3e.as_data().unwrap().len(), long_data.len());
-        let case3s = CardCommandApdu::with_data(0x00, 0xA4, 0x04, 0x00, LengthClass::Short, vec![0x01]).unwrap();
+        let case3s = CardCommandApdu::with_data(
+            0x00,
+            0xA4,
+            0x04,
+            0x00,
+            LengthClass::Short,
+            VecOfU8::new_nonzeroizing(vec![0x01]),
+        )
+        .unwrap();
         assert_eq!(case3s.as_data().unwrap(), [0x01]);
 
         // data+expect short validation
-        assert!(CardCommandApdu::with_data_and_expect(0, 0, 0, 0, LengthClass::Short, vec![0u8; 256], 1).is_err());
+        assert!(CardCommandApdu::with_data_and_expect(
+            0,
+            0,
+            0,
+            0,
+            LengthClass::Short,
+            VecOfU8::new_nonzeroizing(vec![0u8; 256]),
+            1
+        )
+        .is_err());
         let short_data = vec![0xAB];
-        let case4s = CardCommandApdu::with_data_and_expect(0, 0, 0, 0, LengthClass::Short, short_data, 1).unwrap();
+        let case4s = CardCommandApdu::with_data_and_expect(
+            0,
+            0,
+            0,
+            0,
+            LengthClass::Short,
+            VecOfU8::new_nonzeroizing(short_data),
+            1,
+        )
+        .unwrap();
         assert_eq!(case4s.expected_length(), Some(1));
 
         let extended_data = vec![0u8; EXPECTED_LENGTH_WILDCARD_SHORT];
-        let case4e =
-            CardCommandApdu::with_data_and_expect(0, 0, 0, 0, LengthClass::Extended, extended_data, 300).unwrap();
+        let case4e = CardCommandApdu::with_data_and_expect(
+            0,
+            0,
+            0,
+            0,
+            LengthClass::Extended,
+            VecOfU8::new_nonzeroizing(extended_data),
+            300,
+        )
+        .unwrap();
         assert_eq!(case4e.expected_length(), Some(300));
     }
 
@@ -677,7 +710,7 @@ mod tests {
 
     #[test]
     fn test_from_bytes() {
-        let bytes = [0x00, 0xA4, 0x04, 0x00, 0x02, 0x3F, 0x00, 0x00];
+        let bytes = VecOfU8::new_nonzeroizing([0x00, 0xA4, 0x04, 0x00, 0x02, 0x3F, 0x00, 0x00]);
         let command = CardCommandApdu::from_bytes(&bytes).unwrap();
         assert_eq!(command.cla(), 0x00);
         assert_eq!(command.ins(), 0xA4);
@@ -780,31 +813,63 @@ mod tests {
     #[test]
     fn test_command_apdu_validations() {
         assert!(matches!(
-            CardCommandApdu::with_data(0, 0, 0, 0, LengthClass::Short, Vec::<u8>::new()),
+            CardCommandApdu::with_data(0, 0, 0, 0, LengthClass::Short, VecOfU8::new_nonzeroizing(Vec::<u8>::new())),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::with_data(0, 0, 0, 0, LengthClass::Short, vec![0u8; 256]),
+            CardCommandApdu::with_data(0, 0, 0, 0, LengthClass::Short, VecOfU8::new_nonzeroizing(vec![0u8; 256])),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::with_data(0, 0, 0, 0, LengthClass::Extended, vec![0u8; 128]),
+            CardCommandApdu::with_data(0, 0, 0, 0, LengthClass::Extended, VecOfU8::new_nonzeroizing(vec![0u8; 128])),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::with_data_and_expect(0, 0, 0, 0, LengthClass::Extended, vec![0u8; 256], 256),
+            CardCommandApdu::with_data_and_expect(
+                0,
+                0,
+                0,
+                0,
+                LengthClass::Extended,
+                VecOfU8::new_nonzeroizing(vec![0u8; 256]),
+                256
+            ),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::with_data_and_expect(0, 0, 0, 0, LengthClass::Extended, vec![0u8; 255], 257),
+            CardCommandApdu::with_data_and_expect(
+                0,
+                0,
+                0,
+                0,
+                LengthClass::Extended,
+                VecOfU8::new_nonzeroizing(vec![0u8; 255]),
+                257
+            ),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::with_data_and_expect(0, 0, 0, 0, LengthClass::Short, Vec::<u8>::new(), 1),
+            CardCommandApdu::with_data_and_expect(
+                0,
+                0,
+                0,
+                0,
+                LengthClass::Short,
+                VecOfU8::new_nonzeroizing(Vec::<u8>::new()),
+                1
+            ),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::with_data_and_expect(0, 0, 0, 0, LengthClass::Short, vec![0u8; 1], 257),
+            CardCommandApdu::with_data_and_expect(
+                0,
+                0,
+                0,
+                0,
+                LengthClass::Short,
+                VecOfU8::new_nonzeroizing(vec![0u8; 1]),
+                257
+            ),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
@@ -812,11 +877,18 @@ mod tests {
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::new(0, 0, 0, 0, None::<Vec<u8>>, Some(EXPECTED_LENGTH_WILDCARD_EXTENDED + 1)),
+            CardCommandApdu::new(0, 0, 0, 0, None::<VecOfU8>, Some(EXPECTED_LENGTH_WILDCARD_EXTENDED + 1)),
             Err(ApduError::InvalidLength(_))
         ));
         assert!(matches!(
-            CardCommandApdu::new(0, 0, 0, 0, Some(vec![0u8; EXPECTED_LENGTH_WILDCARD_EXTENDED]), None::<usize>),
+            CardCommandApdu::new(
+                0,
+                0,
+                0,
+                0,
+                Some(VecOfU8::new_nonzeroizing(vec![0u8; EXPECTED_LENGTH_WILDCARD_EXTENDED])),
+                None::<usize>
+            ),
             Err(ApduError::InvalidLength(_))
         ));
     }

--- a/core-modules/healthcard/src/command/apdu.rs
+++ b/core-modules/healthcard/src/command/apdu.rs
@@ -19,7 +19,7 @@
 // For additional notes and disclaimer from gematik and in case of changes by gematik,
 // find details in the "Readme" file.
 
-use asn1::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
+use asn1::maybe_zeroizing_vec::{VecOfU8, ZeroizingOption};
 use std::fmt;
 use thiserror::Error;
 
@@ -375,8 +375,9 @@ impl CardCommandApdu {
         };
 
         let apdu: VecOfU8 = {
-            let apdu_zeroing_opt = if let Some(d) = &data_vec { d.get_zeroing_option() } else { ZeroingOption::None };
-            VecOfU8::new(apdu, apdu_zeroing_opt)
+            let apdu_zeroizing_opt =
+                if let Some(d) = &data_vec { d.get_zeroizing_option() } else { ZeroizingOption::None };
+            VecOfU8::new(apdu, apdu_zeroizing_opt)
         };
 
         Ok(CardCommandApdu { apdu, cla, ins, p1, p2, data: data_vec, ne })
@@ -523,43 +524,43 @@ impl CardResponseApdu {
     ///
     /// # Arguments
     /// * `apdu` - The raw byte array of the received APDU.
-    pub fn new_nonzeroing(apdu: &[u8]) -> Result<Self, ApduError> {
-        Self::new(apdu, ZeroingOption::None)
+    pub fn new_nonzeroizing(apdu: &[u8]) -> Result<Self, ApduError> {
+        Self::new(apdu, ZeroizingOption::None)
     }
 
     /// Creates a new CardResponseApdu from a byte array.
     ///
     /// # Arguments
     /// * `apdu` - The raw byte array of the received APDU.
-    /// * `zeroing_option` - Whether the bytes should be zeroed out after use.
-    pub fn new(apdu: &[u8], zeroing_option: ZeroingOption) -> Result<Self, ApduError> {
+    /// * `zeroizing_option` - Whether the bytes should be zeroed out after use.
+    pub fn new(apdu: &[u8], zeroizing_option: ZeroizingOption) -> Result<Self, ApduError> {
         if apdu.len() < 2 {
             return Err(ApduError::InvalidApdu(
                 "Response APDU must contain at least 2 bytes (status bytes SW1, SW2)".to_string(),
             ));
         }
 
-        Ok(CardResponseApdu { bytes: VecOfU8::new(apdu.to_vec(), zeroing_option) })
+        Ok(CardResponseApdu { bytes: VecOfU8::new(apdu.to_vec(), zeroizing_option) })
     }
 
     /// Creates a new CardResponseApdu from a Vec<u8>.
     ///
     /// # Arguments
     /// * `apdu` - A Vec<u8> containing the raw byte array of the received APDU.
-    /// * `zeroing_option` - Whether the bytes should be zeroed out after use.
-    pub fn new_from_vec(apdu: Vec<u8>, zeroing_option: ZeroingOption) -> Result<Self, ApduError> {
+    /// * `zeroizing_option` - Whether the bytes should be zeroed out after use.
+    pub fn new_from_vec(apdu: Vec<u8>, zeroizing_option: ZeroizingOption) -> Result<Self, ApduError> {
         if apdu.len() < 2 {
             return Err(ApduError::InvalidApdu(
                 "Response APDU must contain at least 2 bytes (status bytes SW1, SW2)".to_string(),
             ));
         }
 
-        Ok(CardResponseApdu { bytes: VecOfU8::new(apdu, zeroing_option) })
+        Ok(CardResponseApdu { bytes: VecOfU8::new(apdu, zeroizing_option) })
     }
 
     /// Convenience constructor mirroring `new`.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ApduError> {
-        Self::new_nonzeroing(bytes)
+        Self::new_nonzeroizing(bytes)
     }
 
     /// The data bytes of the response.
@@ -725,7 +726,7 @@ mod tests {
     #[test]
     fn test_card_response_apdu() {
         // Test response APDU with status 9000 (success)
-        let response = CardResponseApdu::new_nonzeroing(&[0x01, 0x02, 0x90, 0x00]).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&[0x01, 0x02, 0x90, 0x00]).unwrap();
         assert_eq!(response.to_data(), vec![0x01, 0x02]);
         assert_eq!(response.sw1(), 0x90);
         assert_eq!(response.sw2(), 0x00);
@@ -919,6 +920,6 @@ mod tests {
 
     #[test]
     fn test_response_apdu_requires_status() {
-        assert!(matches!(CardResponseApdu::new_nonzeroing(&[0x90]), Err(ApduError::InvalidApdu(_))));
+        assert!(matches!(CardResponseApdu::new_nonzeroizing(&[0x90]), Err(ApduError::InvalidApdu(_))));
     }
 }

--- a/core-modules/healthcard/src/command/change_reference_data_command.rs
+++ b/core-modules/healthcard/src/command/change_reference_data_command.rs
@@ -24,6 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::CHANGE_REFERENCE_DATA_STATUS;
+use asn1::maybe_zeroing_vec::VecOfU8;
 
 /// CLA byte for the CHANGE REFERENCE DATA command
 const CLA: u8 = 0x00;
@@ -74,7 +75,7 @@ impl ChangeReferenceDataCommand for HealthCardCommand {
             INS,
             MODE_VERIFICATION_DATA,
             password_reference.calculate_key_reference(df_specific),
-            Some(combined_data),
+            Some(VecOfU8::new_zeroizing(combined_data)),
             None,
         )
     }
@@ -83,6 +84,7 @@ impl ChangeReferenceDataCommand for HealthCardCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use asn1::maybe_zeroing_vec::VecOfU8;
 
     #[test]
     fn test_change_reference_data_command() {
@@ -104,7 +106,7 @@ mod tests {
         expected_data.extend_from_slice(&old_pin_data);
         expected_data.extend_from_slice(&new_pin_data);
 
-        assert_eq!(command.data, Some(expected_data));
+        assert_eq!(command.data, Some(VecOfU8::new_zeroizing(expected_data)));
         assert_eq!(command.ne, None);
 
         let command = HealthCardCommand::change_reference_data(&password_reference, true, &old_secret, &new_secret);

--- a/core-modules/healthcard/src/command/change_reference_data_command.rs
+++ b/core-modules/healthcard/src/command/change_reference_data_command.rs
@@ -24,7 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::CHANGE_REFERENCE_DATA_STATUS;
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 
 /// CLA byte for the CHANGE REFERENCE DATA command
 const CLA: u8 = 0x00;
@@ -84,7 +84,7 @@ impl ChangeReferenceDataCommand for HealthCardCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use asn1::maybe_zeroing_vec::VecOfU8;
+    use asn1::maybe_zeroizing_vec::VecOfU8;
 
     #[test]
     fn test_change_reference_data_command() {

--- a/core-modules/healthcard/src/command/general_authenticate_command.rs
+++ b/core-modules/healthcard/src/command/general_authenticate_command.rs
@@ -73,7 +73,7 @@ impl GeneralAuthenticateCommand for HealthCardCommand {
     fn general_authenticate(command_chaining: bool) -> GeneralAuthenticateResult<HealthCardCommand> {
         let cla = if command_chaining { CLA_COMMAND_CHAINING } else { CLA_NO_COMMAND_CHAINING };
 
-        let data = Asn1Encoder::write(|w| -> Result<(), Asn1EncoderError> {
+        let data = Asn1Encoder::write_nonzeroizing(|w| -> Result<(), Asn1EncoderError> {
             w.write_tagged_object(GENERAL_AUTHENTICATE_TAG.application_tag().constructed(), |_inner| Ok(()))
         })?;
 
@@ -96,7 +96,7 @@ impl GeneralAuthenticateCommand for HealthCardCommand {
         let cla = if command_chaining { CLA_COMMAND_CHAINING } else { CLA_NO_COMMAND_CHAINING };
 
         let data_to_write = data.to_vec();
-        let encoded_data = Asn1Encoder::write(|w| {
+        let encoded_data = Asn1Encoder::write_nonzeroizing(|w| {
             w.write_tagged_object(GENERAL_AUTHENTICATE_TAG.application_tag().constructed(), |inner| {
                 inner.write_tagged_object(tag_no.context_tag(), |innermost| -> Result<(), Asn1EncoderError> {
                     innermost.write_bytes(&data_to_write);

--- a/core-modules/healthcard/src/command/general_authenticate_command.rs
+++ b/core-modules/healthcard/src/command/general_authenticate_command.rs
@@ -96,7 +96,7 @@ impl GeneralAuthenticateCommand for HealthCardCommand {
         let cla = if command_chaining { CLA_COMMAND_CHAINING } else { CLA_NO_COMMAND_CHAINING };
 
         let data_to_write = data.to_vec();
-        let encoded_data = Asn1Encoder::write_nonzeroizing(|w| {
+        let encoded_data = Asn1Encoder::write_zeroizing(|w| {
             w.write_tagged_object(GENERAL_AUTHENTICATE_TAG.application_tag().constructed(), |inner| {
                 inner.write_tagged_object(tag_no.context_tag(), |innermost| -> Result<(), Asn1EncoderError> {
                     innermost.write_bytes(&data_to_write);

--- a/core-modules/healthcard/src/command/health_card_command.rs
+++ b/core-modules/healthcard/src/command/health_card_command.rs
@@ -22,11 +22,11 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use thiserror::Error;
-
 use crate::command::apdu::{ApduError, CardCommandApdu, CardResponseApdu};
 use crate::command::apdu::{EXPECTED_LENGTH_WILDCARD_EXTENDED, EXPECTED_LENGTH_WILDCARD_SHORT};
 use crate::command::health_card_status::HealthCardResponseStatus;
+use asn1::maybe_zeroing_vec::VecOfU8;
+use thiserror::Error;
 
 /// Expected length for a command response.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -66,7 +66,7 @@ pub struct HealthCardCommand {
     /// The parameter 2 byte (P2)
     pub(crate) p2: u8,
     /// The command data
-    pub(crate) data: Option<Vec<u8>>,
+    pub(crate) data: Option<VecOfU8>,
     /// The expected response length
     pub(crate) ne: Option<ExpectedLength>,
 }
@@ -88,7 +88,7 @@ impl HealthCardCommand {
         ins: u8,
         p1: u8,
         p2: u8,
-        data: Option<Vec<u8>>,
+        data: Option<VecOfU8>,
         ne: Option<ExpectedLength>,
     ) -> Self {
         HealthCardCommand { expected_status, cla, ins, p1, p2, data, ne }
@@ -182,7 +182,7 @@ mod tests {
             0xA4,
             0x04,
             0x00,
-            Some(vec![0x3F, 0x00]),
+            Some(VecOfU8::new_nonzeroizing(vec![0x3F, 0x00])),
             Some(ExpectedLength::Exact(256)),
         );
 
@@ -190,7 +190,7 @@ mod tests {
         assert_eq!(command.ins, 0xA4);
         assert_eq!(command.p1, 0x04);
         assert_eq!(command.p2, 0x00);
-        assert_eq!(command.data, Some(vec![0x3F, 0x00]));
+        assert_eq!(command.data, Some(VecOfU8::new_nonzeroizing(vec![0x3F, 0x00])));
         assert_eq!(command.ne, Some(ExpectedLength::Exact(256)));
     }
 

--- a/core-modules/healthcard/src/command/health_card_command.rs
+++ b/core-modules/healthcard/src/command/health_card_command.rs
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn test_health_card_response() {
         let apdu_data = vec![0x90, 0x00];
-        let response_apdu = CardResponseApdu::new(&apdu_data).unwrap();
+        let response_apdu = CardResponseApdu::new_nonzeroing(&apdu_data).unwrap();
         let response = HealthCardResponse::new(HealthCardResponseStatus::Success, response_apdu.clone());
 
         assert!(response.require_success().is_ok());

--- a/core-modules/healthcard/src/command/health_card_command.rs
+++ b/core-modules/healthcard/src/command/health_card_command.rs
@@ -25,7 +25,7 @@ use std::fmt;
 use crate::command::apdu::{ApduError, CardCommandApdu, CardResponseApdu};
 use crate::command::apdu::{EXPECTED_LENGTH_WILDCARD_EXTENDED, EXPECTED_LENGTH_WILDCARD_SHORT};
 use crate::command::health_card_status::HealthCardResponseStatus;
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 use thiserror::Error;
 
 /// Expected length for a command response.
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn test_health_card_response() {
         let apdu_data = vec![0x90, 0x00];
-        let response_apdu = CardResponseApdu::new_nonzeroing(&apdu_data).unwrap();
+        let response_apdu = CardResponseApdu::new_nonzeroizing(&apdu_data).unwrap();
         let response = HealthCardResponse::new(HealthCardResponseStatus::Success, response_apdu.clone());
 
         assert!(response.require_success().is_ok());

--- a/core-modules/healthcard/src/command/manage_security_environment_command.rs
+++ b/core-modules/healthcard/src/command/manage_security_environment_command.rs
@@ -94,7 +94,7 @@ impl ManageSecurityEnvironmentCommand for HealthCardCommand {
         df_specific: bool,
         oid: &[u8],
     ) -> ManageSecurityEnvironmentResult<HealthCardCommand> {
-        let data = Asn1Encoder::write(|w| {
+        let data = Asn1Encoder::write_nonzeroizing(|w| {
             // '80 I2OS(OctetLength(OID), 1) || OID
             w.write_tagged_object(0u8.context_tag(), |inner| -> Result<(), Asn1EncoderError> {
                 inner.write_bytes(oid);
@@ -124,7 +124,7 @@ impl ManageSecurityEnvironmentCommand for HealthCardCommand {
         key: &K,
         df_specific: bool,
     ) -> ManageSecurityEnvironmentResult<HealthCardCommand> {
-        let data = Asn1Encoder::write(|w| {
+        let data = Asn1Encoder::write_nonzeroizing(|w| {
             // '8401 || keyRef'
             w.write_tagged_object(
                 UniversalTag::OctetString.number().context_tag(),

--- a/core-modules/healthcard/src/command/pso_compute_digital_signature_command.rs
+++ b/core-modules/healthcard/src/command/pso_compute_digital_signature_command.rs
@@ -21,7 +21,7 @@
 
 use crate::command::health_card_command::{ExpectedLength, HealthCardCommand};
 use crate::command::health_card_status::PSO_COMPUTE_DIGITAL_SIGNATURE_STATUS;
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 
 /// CLA byte for the PSO COMPUTE DIGITAL SIGNATURE command
 const CLA: u8 = 0x00;

--- a/core-modules/healthcard/src/command/pso_compute_digital_signature_command.rs
+++ b/core-modules/healthcard/src/command/pso_compute_digital_signature_command.rs
@@ -21,6 +21,7 @@
 
 use crate::command::health_card_command::{ExpectedLength, HealthCardCommand};
 use crate::command::health_card_status::PSO_COMPUTE_DIGITAL_SIGNATURE_STATUS;
+use asn1::maybe_zeroing_vec::VecOfU8;
 
 /// CLA byte for the PSO COMPUTE DIGITAL SIGNATURE command
 const CLA: u8 = 0x00;
@@ -52,7 +53,7 @@ impl PsoComputeDigitalSignatureCommand for HealthCardCommand {
             INS,
             P1,
             P2,
-            Some(data_to_be_signed.to_vec()),
+            Some(VecOfU8::new_nonzeroizing(data_to_be_signed.to_vec())),
             Some(ExpectedLength::Any),
         )
     }
@@ -72,7 +73,7 @@ mod tests {
         assert_eq!(cmd.ins, INS);
         assert_eq!(cmd.p1, P1);
         assert_eq!(cmd.p2, P2);
-        assert_eq!(cmd.data, Some(data.to_vec()));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(data.to_vec())));
         assert_eq!(cmd.ne, Some(ExpectedLength::Any));
 
         // Test with empty data
@@ -83,7 +84,7 @@ mod tests {
         assert_eq!(cmd.ins, INS);
         assert_eq!(cmd.p1, P1);
         assert_eq!(cmd.p2, P2);
-        assert_eq!(cmd.data, Some(vec![]));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(vec![])));
         assert_eq!(cmd.ne, Some(ExpectedLength::Any));
 
         // Test with longer data
@@ -94,7 +95,7 @@ mod tests {
         assert_eq!(cmd.ins, INS);
         assert_eq!(cmd.p1, P1);
         assert_eq!(cmd.p2, P2);
-        assert_eq!(cmd.data, Some(long_data.clone()));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(long_data.clone())));
         assert_eq!(cmd.ne, Some(ExpectedLength::Any));
     }
 }

--- a/core-modules/healthcard/src/command/reset_retry_counter_command.rs
+++ b/core-modules/healthcard/src/command/reset_retry_counter_command.rs
@@ -24,6 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::UNLOCK_EGK_STATUS;
+use asn1::maybe_zeroing_vec::VecOfU8;
 
 /// CLA byte for the UNLOCK eGK command
 const CLA: u8 = 0x00;
@@ -67,7 +68,7 @@ impl ResetRetryCounterCommand for HealthCardCommand {
             UNLOCK_EGK_INS,
             MODE_VERIFICATION_DATA,
             password_reference.calculate_key_reference(df_specific),
-            Some(puk.as_bytes().to_vec()),
+            Some(VecOfU8::new_zeroizing(puk.as_bytes().to_vec())),
             None,
         )
     }
@@ -91,7 +92,7 @@ mod tests {
         assert_eq!(cmd.ins, UNLOCK_EGK_INS);
         assert_eq!(cmd.p1, MODE_VERIFICATION_DATA);
         assert_eq!(cmd.p2, password_ref.calculate_key_reference(false));
-        assert_eq!(cmd.data, Some(puk_data.clone()));
+        assert_eq!(cmd.data, Some(VecOfU8::new_zeroizing(puk_data.clone())));
         assert_eq!(cmd.ne, None);
 
         // Test with df_specific = true
@@ -101,7 +102,7 @@ mod tests {
         assert_eq!(cmd.ins, UNLOCK_EGK_INS);
         assert_eq!(cmd.p1, MODE_VERIFICATION_DATA);
         assert_eq!(cmd.p2, password_ref.calculate_key_reference(true));
-        assert_eq!(cmd.data, Some(puk_data));
+        assert_eq!(cmd.data, Some(VecOfU8::new_zeroizing(puk_data)));
         assert_eq!(cmd.ne, None);
     }
 }

--- a/core-modules/healthcard/src/command/reset_retry_counter_command.rs
+++ b/core-modules/healthcard/src/command/reset_retry_counter_command.rs
@@ -24,7 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::UNLOCK_EGK_STATUS;
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 
 /// CLA byte for the UNLOCK eGK command
 const CLA: u8 = 0x00;

--- a/core-modules/healthcard/src/command/reset_retry_counter_with_new_secret_command.rs
+++ b/core-modules/healthcard/src/command/reset_retry_counter_with_new_secret_command.rs
@@ -24,7 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::UNLOCK_EGK_STATUS;
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 
 /// CLA byte for the UNLOCK eGK command
 const CLA: u8 = 0x00;

--- a/core-modules/healthcard/src/command/reset_retry_counter_with_new_secret_command.rs
+++ b/core-modules/healthcard/src/command/reset_retry_counter_with_new_secret_command.rs
@@ -24,6 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::UNLOCK_EGK_STATUS;
+use asn1::maybe_zeroing_vec::VecOfU8;
 
 /// CLA byte for the UNLOCK eGK command
 const CLA: u8 = 0x00;
@@ -75,7 +76,7 @@ impl ResetRetryCounterWithNewSecretCommand for HealthCardCommand {
             UNLOCK_EGK_INS,
             MODE_VERIFICATION_DATA_NEW_SECRET,
             password_reference.calculate_key_reference(df_specific),
-            Some(combined_data),
+            Some(VecOfU8::new_zeroizing(combined_data)),
             None,
         )
     }
@@ -106,7 +107,7 @@ mod tests {
         expected_data.extend_from_slice(&puk_data);
         expected_data.extend_from_slice(&new_pin_data);
 
-        assert_eq!(cmd.data, Some(expected_data.clone()));
+        assert_eq!(cmd.data, Some(VecOfU8::new_zeroizing(expected_data.clone())));
         assert_eq!(cmd.ne, None);
 
         // Test with df_specific = true
@@ -116,7 +117,7 @@ mod tests {
         assert_eq!(cmd.ins, UNLOCK_EGK_INS);
         assert_eq!(cmd.p1, MODE_VERIFICATION_DATA_NEW_SECRET);
         assert_eq!(cmd.p2, password_ref.calculate_key_reference(true));
-        assert_eq!(cmd.data, Some(expected_data));
+        assert_eq!(cmd.data, Some(VecOfU8::new_zeroizing(expected_data)));
         assert_eq!(cmd.ne, None);
     }
 }

--- a/core-modules/healthcard/src/command/select_command.rs
+++ b/core-modules/healthcard/src/command/select_command.rs
@@ -23,6 +23,7 @@ use crate::command::apdu::EXPECTED_LENGTH_WILDCARD_SHORT;
 use crate::command::health_card_command::{ExpectedLength, HealthCardCommand};
 use crate::command::health_card_status::SELECT_STATUS;
 use crate::identifier::{ApplicationIdentifier, FileIdentifier};
+use asn1::maybe_zeroing_vec::VecOfU8;
 
 const CLA: u8 = 0x00;
 const INS: u8 = 0xA4;
@@ -144,7 +145,7 @@ impl SelectCommand for HealthCardCommand {
             INS,
             SELECTION_MODE_AID,
             p2,
-            Some(aid.as_bytes().to_vec()),
+            Some(VecOfU8::new_nonzeroizing(aid.as_bytes().to_vec())),
             ne,
         )
     }
@@ -173,7 +174,15 @@ impl SelectCommand for HealthCardCommand {
             None
         };
 
-        HealthCardCommand::new(SELECT_STATUS.clone(), CLA, INS, p1, p2, Some(fid.to_bytes().to_vec()), ne)
+        HealthCardCommand::new(
+            SELECT_STATUS.clone(),
+            CLA,
+            INS,
+            p1,
+            p2,
+            Some(VecOfU8::new_nonzeroizing(fid.to_bytes())),
+            ne,
+        )
     }
 }
 
@@ -224,7 +233,7 @@ mod tests {
         assert_eq!(cmd.ins, INS);
         assert_eq!(cmd.p1, SELECTION_MODE_AID);
         assert_eq!(cmd.p2, RESPONSE_TYPE_NO_RESPONSE);
-        assert_eq!(cmd.data, Some(vec![0x12, 0x34, 0x56, 0x78, 0x90]));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(vec![0x12, 0x34, 0x56, 0x78, 0x90])));
         assert_eq!(cmd.ne, None);
     }
 
@@ -236,7 +245,7 @@ mod tests {
         assert_eq!(cmd.ins, INS);
         assert_eq!(cmd.p1, SELECTION_MODE_AID);
         assert_eq!(cmd.p2, RESPONSE_TYPE_FCP + FILE_OCCURRENCE_NEXT);
-        assert_eq!(cmd.data, Some(vec![0x12, 0x34, 0x56, 0x78, 0x90]));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(vec![0x12, 0x34, 0x56, 0x78, 0x90])));
         assert_eq!(cmd.ne, Some(ExpectedLength::Exact(128)));
     }
 
@@ -257,7 +266,7 @@ mod tests {
         assert_eq!(cmd.ins, INS);
         assert_eq!(cmd.p1, SELECTION_MODE_DF_BY_FID);
         assert_eq!(cmd.p2, RESPONSE_TYPE_NO_RESPONSE);
-        assert_eq!(cmd.data, Some(vec![0xAB, 0xCD]));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(vec![0xAB, 0xCD])));
         assert_eq!(cmd.ne, None);
     }
 
@@ -270,7 +279,7 @@ mod tests {
         assert_eq!(cmd.ins, INS);
         assert_eq!(cmd.p1, SELECTION_MODE_EF_BY_FID);
         assert_eq!(cmd.p2, RESPONSE_TYPE_FCP);
-        assert_eq!(cmd.data, Some(vec![0xAB, 0xCD]));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(vec![0xAB, 0xCD])));
         assert_eq!(cmd.ne, Some(ExpectedLength::Exact(64)));
     }
 

--- a/core-modules/healthcard/src/command/select_command.rs
+++ b/core-modules/healthcard/src/command/select_command.rs
@@ -23,7 +23,7 @@ use crate::command::apdu::EXPECTED_LENGTH_WILDCARD_SHORT;
 use crate::command::health_card_command::{ExpectedLength, HealthCardCommand};
 use crate::command::health_card_status::SELECT_STATUS;
 use crate::identifier::{ApplicationIdentifier, FileIdentifier};
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 
 const CLA: u8 = 0x00;
 const INS: u8 = 0xA4;

--- a/core-modules/healthcard/src/command/verify_pin_command.rs
+++ b/core-modules/healthcard/src/command/verify_pin_command.rs
@@ -24,6 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::VERIFY_SECRET_STATUS;
+use asn1::maybe_zeroing_vec::VecOfU8;
 
 /// CLA byte for the VERIFY SECRET command
 const CLA: u8 = 0x00;
@@ -62,7 +63,7 @@ impl VerifyCommand for HealthCardCommand {
             VERIFY_SECRET_INS,
             MODE_VERIFICATION_DATA,
             password_reference.calculate_key_reference(df_specific),
-            Some(pin.as_bytes().to_vec()),
+            Some(VecOfU8::new_nonzeroizing(pin.as_bytes())),
             None,
         )
     }
@@ -87,7 +88,7 @@ mod tests {
         assert_eq!(cmd.ins, VERIFY_SECRET_INS);
         assert_eq!(cmd.p1, MODE_VERIFICATION_DATA);
         assert_eq!(cmd.p2, password_ref.calculate_key_reference(true));
-        assert_eq!(cmd.data, Some(pin_data.clone()));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(pin_data.clone())));
         assert_eq!(cmd.ne, None);
 
         // Test with df_specific = false
@@ -96,7 +97,7 @@ mod tests {
         assert_eq!(cmd.ins, VERIFY_SECRET_INS);
         assert_eq!(cmd.p1, MODE_VERIFICATION_DATA);
         assert_eq!(cmd.p2, password_ref.calculate_key_reference(false));
-        assert_eq!(cmd.data, Some(pin_data));
+        assert_eq!(cmd.data, Some(VecOfU8::new_nonzeroizing(pin_data)));
         assert_eq!(cmd.ne, None);
     }
 }

--- a/core-modules/healthcard/src/command/verify_pin_command.rs
+++ b/core-modules/healthcard/src/command/verify_pin_command.rs
@@ -24,7 +24,7 @@ use crate::card::encrypted_pin_format2::EncryptedPinFormat2;
 use crate::card::password_reference::PasswordReference;
 use crate::command::health_card_command::HealthCardCommand;
 use crate::command::health_card_status::VERIFY_SECRET_STATUS;
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8;
 
 /// CLA byte for the VERIFY SECRET command
 const CLA: u8 = 0x00;

--- a/core-modules/healthcard/src/exchange/certificate.rs
+++ b/core-modules/healthcard/src/exchange/certificate.rs
@@ -116,7 +116,7 @@ mod tests {
     use crate::command::health_card_status::HealthCardResponseStatus;
     use crate::command::select_command::SelectCommand;
     use crate::exchange::test_utils::MockSession;
-    use asn1::maybe_zeroing_vec::VecOfU8;
+    use asn1::maybe_zeroizing_vec::VecOfU8;
 
     #[test]
     fn certificate_read_until_eof() {

--- a/core-modules/healthcard/src/exchange/certificate.rs
+++ b/core-modules/healthcard/src/exchange/certificate.rs
@@ -116,6 +116,7 @@ mod tests {
     use crate::command::health_card_status::HealthCardResponseStatus;
     use crate::command::select_command::SelectCommand;
     use crate::exchange::test_utils::MockSession;
+    use asn1::maybe_zeroing_vec::VecOfU8;
 
     #[test]
     fn certificate_read_until_eof() {
@@ -150,11 +151,11 @@ mod tests {
         let cert = retrieve_certificate_from(&mut session, CertificateFile::EgkAutCvcE256).unwrap();
         assert_eq!(cert, vec![0xDE, 0xAD, 0xBE, 0xEF]);
         assert_eq!(
-            session.recorded[0],
+            VecOfU8::new_nonzeroizing(session.recorded[0].clone()),
             HealthCardCommand::select(false, false).command_apdu(false).unwrap().to_bytes()
         );
         assert_eq!(
-            session.recorded[1],
+            VecOfU8::new_nonzeroizing(session.recorded[1].clone()),
             HealthCardCommand::select_fid_with_options(
                 &ids::ef_c_egk_aut_cvc_e256_fid(),
                 false,

--- a/core-modules/healthcard/src/exchange/certificate.rs
+++ b/core-modules/healthcard/src/exchange/certificate.rs
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(cert, vec![0xDE, 0xAD, 0xBE, 0xEF]);
         assert_eq!(
             VecOfU8::new_nonzeroizing(session.recorded[0].clone()),
-            HealthCardCommand::select(false, false).command_apdu(false).unwrap().to_bytes()
+            HealthCardCommand::select(false, false).command_apdu(false).unwrap().to_vec()
         );
         assert_eq!(
             VecOfU8::new_nonzeroizing(session.recorded[1].clone()),
@@ -164,7 +164,7 @@ mod tests {
             )
             .command_apdu(false)
             .unwrap()
-            .to_bytes()
+            .to_vec()
         );
     }
 }

--- a/core-modules/healthcard/src/exchange/pace_info.rs
+++ b/core-modules/healthcard/src/exchange/pace_info.rs
@@ -57,7 +57,7 @@ impl PaceInfo {
     pub fn protocol_id_bytes(&self) -> Vec<u8> {
         // Encode full TLV first
         let encoded =
-            Asn1Encoder::write(|w| w.write_object_identifier(&self.protocol_id)).expect("OID encoding must not fail");
+            Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&self.protocol_id)).expect("OID encoding must not fail");
         // Strip tag (1+ bytes) + length (1+ bytes) in a DER-compliant way
         // Tag is at least 1 byte; for UNIVERSAL OBJECT IDENTIFIER it's one byte (0x06),
         // but we still parse length generically.

--- a/core-modules/healthcard/src/exchange/pace_info.rs
+++ b/core-modules/healthcard/src/exchange/pace_info.rs
@@ -56,8 +56,8 @@ impl PaceInfo {
     /// Returns the protocol ID bytes without the tag and length
     pub fn protocol_id_bytes(&self) -> Vec<u8> {
         // Encode full TLV first
-        let encoded =
-            Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&self.protocol_id)).expect("OID encoding must not fail");
+        let encoded = Asn1Encoder::write_nonzeroizing(|w| w.write_object_identifier(&self.protocol_id))
+            .expect("OID encoding must not fail");
         // Strip tag (1+ bytes) + length (1+ bytes) in a DER-compliant way
         // Tag is at least 1 byte; for UNIVERSAL OBJECT IDENTIFIER it's one byte (0x06),
         // but we still parse length generically.

--- a/core-modules/healthcard/src/exchange/pin.rs
+++ b/core-modules/healthcard/src/exchange/pin.rs
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn map_verify_response_unexpected_status() {
-        let apdu = crate::command::apdu::CardResponseApdu::new(&[0x69, 0x82]).unwrap();
+        let apdu = crate::command::apdu::CardResponseApdu::new_nonzeroing(&[0x69, 0x82]).unwrap();
         let response = HealthCardResponse::new(HealthCardResponseStatus::SecurityStatusNotSatisfied, apdu);
         let err = map_verify_response(response).unwrap_err();
         assert!(matches!(err, ExchangeError::UnexpectedStatus { .. }));

--- a/core-modules/healthcard/src/exchange/pin.rs
+++ b/core-modules/healthcard/src/exchange/pin.rs
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn map_verify_response_unexpected_status() {
-        let apdu = crate::command::apdu::CardResponseApdu::new_nonzeroing(&[0x69, 0x82]).unwrap();
+        let apdu = crate::command::apdu::CardResponseApdu::new_nonzeroizing(&[0x69, 0x82]).unwrap();
         let response = HealthCardResponse::new(HealthCardResponseStatus::SecurityStatusNotSatisfied, apdu);
         let err = map_verify_response(response).unwrap_err();
         assert!(matches!(err, ExchangeError::UnexpectedStatus { .. }));

--- a/core-modules/healthcard/src/exchange/random.rs
+++ b/core-modules/healthcard/src/exchange/random.rs
@@ -61,7 +61,7 @@ mod tests {
         assert_eq!(session.recorded.len(), 2);
         assert_eq!(
             VecOfU8::new_nonzeroizing(session.recorded[0].clone()),
-            HealthCardCommand::select(false, false).command_apdu(false).unwrap().to_bytes()
+            HealthCardCommand::select(false, false).command_apdu(false).unwrap().to_vec()
         );
     }
 }

--- a/core-modules/healthcard/src/exchange/random.rs
+++ b/core-modules/healthcard/src/exchange/random.rs
@@ -51,7 +51,7 @@ mod tests {
     use super::*;
     use crate::command::select_command::SelectCommand;
     use crate::exchange::test_utils::MockSession;
-    use asn1::maybe_zeroing_vec::VecOfU8;
+    use asn1::maybe_zeroizing_vec::VecOfU8;
 
     #[test]
     fn random_success() {

--- a/core-modules/healthcard/src/exchange/random.rs
+++ b/core-modules/healthcard/src/exchange/random.rs
@@ -51,6 +51,7 @@ mod tests {
     use super::*;
     use crate::command::select_command::SelectCommand;
     use crate::exchange::test_utils::MockSession;
+    use asn1::maybe_zeroing_vec::VecOfU8;
 
     #[test]
     fn random_success() {
@@ -59,7 +60,7 @@ mod tests {
         assert_eq!(values, vec![0xDE, 0xAD]);
         assert_eq!(session.recorded.len(), 2);
         assert_eq!(
-            session.recorded[0],
+            VecOfU8::new_nonzeroizing(session.recorded[0].clone()),
             HealthCardCommand::select(false, false).command_apdu(false).unwrap().to_bytes()
         );
     }

--- a/core-modules/healthcard/src/exchange/secure_channel.rs
+++ b/core-modules/healthcard/src/exchange/secure_channel.rs
@@ -37,7 +37,7 @@ use asn1::decoder::{Asn1Decoder, Asn1Length};
 use asn1::encoder::Asn1Encoder;
 use asn1::error::Asn1DecoderError;
 use asn1::error::Asn1EncoderError;
-use asn1::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
+use asn1::maybe_zeroizing_vec::{VecOfU8, ZeroizingOption};
 use asn1::oid::ObjectIdentifier;
 use asn1::tag::{Asn1Class, Asn1Id};
 use crypto::cipher::aes::{AesCipherSpec, AesDecipherSpec, Cipher, Iv, Padding};
@@ -269,7 +269,7 @@ impl<S: CardChannel> SecureChannel<S> {
         }
 
         plaintext.extend_from_slice(&status_bytes);
-        CardResponseApdu::new_from_vec(plaintext, ZeroingOption::Zeroes).map_err(ExchangeError::Apdu)
+        CardResponseApdu::new_from_vec(plaintext, ZeroizingOption::Zeroes).map_err(ExchangeError::Apdu)
     }
 
     fn increment_ssc(&mut self) -> [u8; 16] {
@@ -823,7 +823,7 @@ mod tests {
     #[test]
     fn decrypt_do99_only() {
         let response =
-            CardResponseApdu::new_nonzeroing(&hex::decode("990290008E08087631D746F872729000").unwrap()).unwrap();
+            CardResponseApdu::new_nonzeroizing(&hex::decode("990290008E08087631D746F872729000").unwrap()).unwrap();
         let mut scope = make_channel();
         let plain = scope.decrypt(response).unwrap();
         assert_eq!(hex::encode_upper(plain.to_vec()), "9000");
@@ -831,7 +831,7 @@ mod tests {
 
     #[test]
     fn decrypt_status_only_passthrough() {
-        let response = CardResponseApdu::new_nonzeroing(&[0x63, 0xC0]).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&[0x63, 0xC0]).unwrap();
         let mut scope = make_channel();
         let plain = scope.decrypt(response).unwrap();
         assert_eq!(plain.sw(), 0x63C0);
@@ -840,7 +840,7 @@ mod tests {
 
     #[test]
     fn decrypt_do87_and_do99() {
-        let response = CardResponseApdu::new_nonzeroing(
+        let response = CardResponseApdu::new_nonzeroizing(
             &hex::decode("871101496C26D36306679609665A385C54DB37990290008E08B7E9ED2A0C89FB3A9000").unwrap(),
         )
         .unwrap();
@@ -869,7 +869,7 @@ mod tests {
 
         let mut apdu = body;
         apdu.extend_from_slice(&[0x90, 0x00]);
-        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&apdu).unwrap();
         let plain = scope.decrypt(response).unwrap();
         assert_eq!(hex::encode_upper(plain.to_vec()), "CAFE9000");
     }
@@ -912,7 +912,7 @@ mod tests {
 
     #[test]
     fn decrypt_rejects_short_response() {
-        let response = CardResponseApdu::new_nonzeroing(&[0x90, 0x00, 0x01]).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&[0x90, 0x00, 0x01]).unwrap();
         let mut scope = make_channel();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
@@ -927,7 +927,7 @@ mod tests {
         body.extend_from_slice(&do8e);
         let mut apdu = body;
         apdu.extend_from_slice(&[0x6F, 0x00]);
-        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&apdu).unwrap();
         let mut scope = make_channel();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
@@ -938,7 +938,7 @@ mod tests {
         let mut bytes = hex::decode("990290008E08087631D746F872729000").unwrap();
         let last = bytes.len() - 3;
         bytes[last] ^= 0xFF;
-        let response = CardResponseApdu::new_nonzeroing(&bytes).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&bytes).unwrap();
         let mut scope = make_channel();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::MutualAuthenticationFailed));
@@ -964,7 +964,7 @@ mod tests {
 
         let mut apdu = body;
         apdu.extend_from_slice(&[0x90, 0x00]);
-        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&apdu).unwrap();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
     }
@@ -995,7 +995,7 @@ mod tests {
 
         let mut apdu = body;
         apdu.extend_from_slice(&[0x90, 0x00]);
-        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&apdu).unwrap();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
     }

--- a/core-modules/healthcard/src/exchange/secure_channel.rs
+++ b/core-modules/healthcard/src/exchange/secure_channel.rs
@@ -37,7 +37,7 @@ use asn1::decoder::{Asn1Decoder, Asn1Length};
 use asn1::encoder::Asn1Encoder;
 use asn1::error::Asn1DecoderError;
 use asn1::error::Asn1EncoderError;
-use asn1::maybe_zeroing_vec::VecOfU8;
+use asn1::maybe_zeroing_vec::{VecOfU8, ZeroingOption};
 use asn1::oid::ObjectIdentifier;
 use asn1::tag::{Asn1Class, Asn1Id};
 use crypto::cipher::aes::{AesCipherSpec, AesDecipherSpec, Cipher, Iv, Padding};
@@ -230,7 +230,7 @@ impl<S: CardChannel> SecureChannel<S> {
             return Err(ExchangeError::invalid_argument("response apdu too short"));
         }
 
-        let bytes = response.into_bytes();
+        let bytes = response.into_vec();
         let (body, sw_bytes) = bytes.split_at(bytes.len() - 2);
 
         let response_objects = parse_response_objects(body)?;
@@ -269,7 +269,7 @@ impl<S: CardChannel> SecureChannel<S> {
         }
 
         plaintext.extend_from_slice(&status_bytes);
-        CardResponseApdu::new(&plaintext).map_err(ExchangeError::Apdu)
+        CardResponseApdu::new_from_vec(plaintext, ZeroingOption::Zeroes).map_err(ExchangeError::Apdu)
     }
 
     fn increment_ssc(&mut self) -> [u8; 16] {
@@ -756,7 +756,7 @@ mod tests {
     }
 
     fn to_hex(apdu: &CardCommandApdu) -> String {
-        hex::encode_upper(apdu.to_bytes())
+        hex::encode_upper(apdu.to_vec())
     }
 
     #[test]
@@ -822,15 +822,16 @@ mod tests {
 
     #[test]
     fn decrypt_do99_only() {
-        let response = CardResponseApdu::new(&hex::decode("990290008E08087631D746F872729000").unwrap()).unwrap();
+        let response =
+            CardResponseApdu::new_nonzeroing(&hex::decode("990290008E08087631D746F872729000").unwrap()).unwrap();
         let mut scope = make_channel();
         let plain = scope.decrypt(response).unwrap();
-        assert_eq!(hex::encode_upper(plain.to_bytes()), "9000");
+        assert_eq!(hex::encode_upper(plain.to_vec()), "9000");
     }
 
     #[test]
     fn decrypt_status_only_passthrough() {
-        let response = CardResponseApdu::new(&[0x63, 0xC0]).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&[0x63, 0xC0]).unwrap();
         let mut scope = make_channel();
         let plain = scope.decrypt(response).unwrap();
         assert_eq!(plain.sw(), 0x63C0);
@@ -839,13 +840,13 @@ mod tests {
 
     #[test]
     fn decrypt_do87_and_do99() {
-        let response = CardResponseApdu::new(
+        let response = CardResponseApdu::new_nonzeroing(
             &hex::decode("871101496C26D36306679609665A385C54DB37990290008E08B7E9ED2A0C89FB3A9000").unwrap(),
         )
         .unwrap();
         let mut scope = make_channel();
         let plain = scope.decrypt(response).unwrap();
-        assert_eq!(hex::encode_upper(plain.to_bytes()), "05060708090A9000");
+        assert_eq!(hex::encode_upper(plain.to_vec()), "05060708090A9000");
     }
 
     #[test]
@@ -868,9 +869,9 @@ mod tests {
 
         let mut apdu = body;
         apdu.extend_from_slice(&[0x90, 0x00]);
-        let response = CardResponseApdu::new(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
         let plain = scope.decrypt(response).unwrap();
-        assert_eq!(hex::encode_upper(plain.to_bytes()), "CAFE9000");
+        assert_eq!(hex::encode_upper(plain.to_vec()), "CAFE9000");
     }
 
     #[test]
@@ -911,7 +912,7 @@ mod tests {
 
     #[test]
     fn decrypt_rejects_short_response() {
-        let response = CardResponseApdu::new(&[0x90, 0x00, 0x01]).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&[0x90, 0x00, 0x01]).unwrap();
         let mut scope = make_channel();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
@@ -926,7 +927,7 @@ mod tests {
         body.extend_from_slice(&do8e);
         let mut apdu = body;
         apdu.extend_from_slice(&[0x6F, 0x00]);
-        let response = CardResponseApdu::new(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
         let mut scope = make_channel();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
@@ -937,7 +938,7 @@ mod tests {
         let mut bytes = hex::decode("990290008E08087631D746F872729000").unwrap();
         let last = bytes.len() - 3;
         bytes[last] ^= 0xFF;
-        let response = CardResponseApdu::new(&bytes).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&bytes).unwrap();
         let mut scope = make_channel();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::MutualAuthenticationFailed));
@@ -963,7 +964,7 @@ mod tests {
 
         let mut apdu = body;
         apdu.extend_from_slice(&[0x90, 0x00]);
-        let response = CardResponseApdu::new(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
     }
@@ -994,7 +995,7 @@ mod tests {
 
         let mut apdu = body;
         apdu.extend_from_slice(&[0x90, 0x00]);
-        let response = CardResponseApdu::new(&apdu).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&apdu).unwrap();
         let err = scope.decrypt(response).unwrap_err();
         assert!(matches!(err, ExchangeError::InvalidArgument(_)));
     }

--- a/core-modules/healthcard/src/exchange/secure_channel.rs
+++ b/core-modules/healthcard/src/exchange/secure_channel.rs
@@ -443,7 +443,7 @@ fn decode_general_authenticate(data: &[u8]) -> Result<Vec<u8>, ExchangeError> {
 }
 
 fn create_asn1_auth_token(public_key: &EcPublicKey, protocol_id: &ObjectIdentifier) -> Result<Vec<u8>, ExchangeError> {
-    Asn1Encoder::write::<Asn1EncoderError>(|writer| {
+    Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|writer| {
         writer.write_tagged_object(Asn1Id::app(0x49).constructed(), |outer| {
             outer.write_object_identifier(protocol_id)?;
             outer.write_tagged_object(Asn1Id::ctx(0x06).primitive(), |inner| -> Result<(), Asn1EncoderError> {
@@ -568,7 +568,7 @@ fn encode_length_object(le: usize) -> Vec<u8> {
 }
 
 fn encode_context_specific(tag_number: u32, value: &[u8]) -> Result<Vec<u8>, ExchangeError> {
-    Asn1Encoder::write::<Asn1EncoderError>(|writer| {
+    Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|writer| {
         writer.write_tagged_object(Asn1Id::ctx(tag_number).primitive(), |scope| {
             scope.write_bytes(value);
             Ok(())

--- a/core-modules/healthcard/src/exchange/secure_channel.rs
+++ b/core-modules/healthcard/src/exchange/secure_channel.rs
@@ -37,6 +37,7 @@ use asn1::decoder::{Asn1Decoder, Asn1Length};
 use asn1::encoder::Asn1Encoder;
 use asn1::error::Asn1DecoderError;
 use asn1::error::Asn1EncoderError;
+use asn1::maybe_zeroing_vec::VecOfU8;
 use asn1::oid::ObjectIdentifier;
 use asn1::tag::{Asn1Class, Asn1Id};
 use crypto::cipher::aes::{AesCipherSpec, AesDecipherSpec, Cipher, Iv, Padding};
@@ -205,8 +206,15 @@ impl<S: CardChannel> SecureChannel<S> {
         let ne =
             if expected_length.is_some() { EXPECTED_LENGTH_WILDCARD_EXTENDED } else { EXPECTED_LENGTH_WILDCARD_SHORT };
 
-        CardCommandApdu::new(header[0], header[1], header[2], header[3], Some(command_body), Some(ne))
-            .map_err(ExchangeError::Apdu)
+        CardCommandApdu::new(
+            header[0],
+            header[1],
+            header[2],
+            header[3],
+            Some(VecOfU8::new_zeroizing(command_body)),
+            Some(ne),
+        )
+        .map_err(ExchangeError::Apdu)
     }
 
     /// Decrypt and verify a secure messaging response.
@@ -442,7 +450,7 @@ fn decode_general_authenticate(data: &[u8]) -> Result<Vec<u8>, ExchangeError> {
         .map_err(ExchangeError::from)
 }
 
-fn create_asn1_auth_token(public_key: &EcPublicKey, protocol_id: &ObjectIdentifier) -> Result<Vec<u8>, ExchangeError> {
+fn create_asn1_auth_token(public_key: &EcPublicKey, protocol_id: &ObjectIdentifier) -> Result<VecOfU8, ExchangeError> {
     Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|writer| {
         writer.write_tagged_object(Asn1Id::app(0x49).constructed(), |outer| {
             outer.write_object_identifier(protocol_id)?;
@@ -567,7 +575,7 @@ fn encode_length_object(le: usize) -> Vec<u8> {
     }
 }
 
-fn encode_context_specific(tag_number: u32, value: &[u8]) -> Result<Vec<u8>, ExchangeError> {
+fn encode_context_specific(tag_number: u32, value: &[u8]) -> Result<VecOfU8, ExchangeError> {
     Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|writer| {
         writer.write_tagged_object(Asn1Id::ctx(tag_number).primitive(), |scope| {
             scope.write_bytes(value);
@@ -653,7 +661,7 @@ struct SecureDataObject {
 }
 
 impl SecureDataObject {
-    fn encoded(&self) -> Result<Vec<u8>, ExchangeError> {
+    fn encoded(&self) -> Result<VecOfU8, ExchangeError> {
         encode_context_specific(self.tag_number, &self.value)
     }
 
@@ -780,7 +788,7 @@ mod tests {
     #[test]
     fn encrypt_case3_short_data() {
         let data = vec![0x05, 0x06, 0x07, 0x08, 0x09, 0x0A];
-        let command = CardCommandApdu::new(0x01, 0x02, 0x03, 0x04, Some(data), None).unwrap();
+        let command = CardCommandApdu::new(0x01, 0x02, 0x03, 0x04, Some(VecOfU8::new_zeroizing(data)), None).unwrap();
         let mut scope = make_channel();
         let secured = scope.encrypt(&command).unwrap();
         assert_eq!(to_hex(&secured), "0D0203041D871101496C26D36306679609665A385C54DB378E08E7AAD918F260D8EF00");
@@ -789,7 +797,8 @@ mod tests {
     #[test]
     fn encrypt_case4_short_data_with_le() {
         let data = vec![0x05, 0x06, 0x07, 0x08, 0x09, 0x0A];
-        let command = CardCommandApdu::new(0x01, 0x02, 0x03, 0x04, Some(data), Some(127)).unwrap();
+        let command =
+            CardCommandApdu::new(0x01, 0x02, 0x03, 0x04, Some(VecOfU8::new_zeroizing(data)), Some(127)).unwrap();
         let mut scope = make_channel();
         let secured = scope.encrypt(&command).unwrap();
         assert_eq!(
@@ -801,7 +810,8 @@ mod tests {
     #[test]
     fn encrypt_case4_extended_data_with_le() {
         let data = vec![0u8; 256];
-        let command = CardCommandApdu::new(0x01, 0x02, 0x03, 0x04, Some(data), Some(127)).unwrap();
+        let command =
+            CardCommandApdu::new(0x01, 0x02, 0x03, 0x04, Some(VecOfU8::new_zeroizing(data)), Some(127)).unwrap();
         let mut scope = make_channel();
         let secured = scope.encrypt(&command).unwrap();
         assert_eq!(

--- a/core-modules/healthcard/src/exchange/test_utils.rs
+++ b/core-modules/healthcard/src/exchange/test_utils.rs
@@ -38,8 +38,10 @@ impl MockSession {
 
     /// Create a mock session with an explicit extended-length capability flag.
     pub(crate) fn with_extended_support(responses: Vec<Vec<u8>>, supports_extended_length: bool) -> Self {
-        let responses =
-            responses.into_iter().map(|raw| CardResponseApdu::new(&raw).expect("valid response APDU")).collect();
+        let responses = responses
+            .into_iter()
+            .map(|raw| CardResponseApdu::new_nonzeroing(&raw).expect("valid response APDU"))
+            .collect();
         Self { responses, recorded: Vec::new(), supports_extended_length }
     }
 }
@@ -52,7 +54,7 @@ impl CardChannel for MockSession {
     }
 
     fn transmit(&mut self, command: &CardCommandApdu) -> Result<CardResponseApdu, Self::Error> {
-        self.recorded.push(command.to_bytes().as_ref().to_vec());
+        self.recorded.push(command.to_vec().as_ref().to_vec());
         if self.responses.is_empty() {
             Err(ExchangeError::Transport { code: 0, message: "mock session ran out of responses".to_string() })
         } else {

--- a/core-modules/healthcard/src/exchange/test_utils.rs
+++ b/core-modules/healthcard/src/exchange/test_utils.rs
@@ -52,7 +52,7 @@ impl CardChannel for MockSession {
     }
 
     fn transmit(&mut self, command: &CardCommandApdu) -> Result<CardResponseApdu, Self::Error> {
-        self.recorded.push(command.to_bytes());
+        self.recorded.push(command.to_bytes().as_ref().to_vec());
         if self.responses.is_empty() {
             Err(ExchangeError::Transport { code: 0, message: "mock session ran out of responses".to_string() })
         } else {

--- a/core-modules/healthcard/src/exchange/test_utils.rs
+++ b/core-modules/healthcard/src/exchange/test_utils.rs
@@ -40,7 +40,7 @@ impl MockSession {
     pub(crate) fn with_extended_support(responses: Vec<Vec<u8>>, supports_extended_length: bool) -> Self {
         let responses = responses
             .into_iter()
-            .map(|raw| CardResponseApdu::new_nonzeroing(&raw).expect("valid response APDU"))
+            .map(|raw| CardResponseApdu::new_nonzeroizing(&raw).expect("valid response APDU"))
             .collect();
         Self { responses, recorded: Vec::new(), supports_extended_length }
     }

--- a/core-modules/healthcard/src/ffi/README.md
+++ b/core-modules/healthcard/src/ffi/README.md
@@ -50,8 +50,8 @@ semantics.
 
 Defined in `channel.rs`:
 
-- `CommandApdu`: constructors for building command APDUs, plus `to_bytes()`.
-- `ResponseApdu`: object exposing `sw()`, `data()`, and `to_bytes()`.
+- `CommandApdu`: constructors for building command APDUs, plus `to_vec()`.
+- `ResponseApdu`: object exposing `sw()`, `data()`, and `to_vec()`.
   Construct via `ResponseApdu::from_bytes(...)` or `ResponseApdu::from_parts(sw, data)`.
 - `CardChannelError`: error returned by the foreign channel implementation (`Transport` vs `Apdu`).
 

--- a/core-modules/healthcard/src/ffi/channel.rs
+++ b/core-modules/healthcard/src/ffi/channel.rs
@@ -22,8 +22,8 @@
 use crate::command::apdu::{ApduError, CardCommandApdu, CardResponseApdu};
 use crate::exchange::channel::CardChannel as CoreCardChannel;
 use crate::exchange::ExchangeError;
-use crate::ffi::maybe_zeroing_vec::VecOfU8 as FfiVecOfU8;
-use asn1::maybe_zeroing_vec::VecOfU8 as Asn1VecOfU8;
+use crate::ffi::maybe_zeroizing_vec::VecOfU8 as FfiVecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8 as Asn1VecOfU8;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
@@ -188,7 +188,7 @@ impl ResponseApdu {
         let mut full = data;
         full.push((sw >> 8) as u8);
         full.push(sw as u8);
-        Ok(ResponseApdu { inner: CardResponseApdu::new_nonzeroing(&full)? })
+        Ok(ResponseApdu { inner: CardResponseApdu::new_nonzeroizing(&full)? })
     }
 
     /// Returns the status word (SW1SW2) as `0xSW1SW2` (big-endian).
@@ -300,7 +300,7 @@ impl From<CardChannelError> for ExchangeError {
 mod tests {
     use super::*;
     use crate::command::apdu::{CardCommandApdu, EXPECTED_LENGTH_WILDCARD_EXTENDED};
-    use crate::ffi::maybe_zeroing_vec::VecOfU8 as FfiVecOfU8;
+    use crate::ffi::maybe_zeroizing_vec::VecOfU8 as FfiVecOfU8;
 
     #[test]
     fn command_apdu_roundtrip() {
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn response_apdu_conversion_preserves_bytes() {
-        let response = CardResponseApdu::new_nonzeroing(&[0xDE, 0xAD, 0x90, 0x00]).unwrap();
+        let response = CardResponseApdu::new_nonzeroizing(&[0xDE, 0xAD, 0x90, 0x00]).unwrap();
         let ffi_apdu = ResponseApdu::from_core(response.clone());
         let rebuilt = CardResponseApdu::try_from(ffi_apdu.as_ref()).unwrap();
         assert_eq!(rebuilt.to_vec(), response.to_vec());
@@ -337,7 +337,7 @@ mod tests {
         let ffi_apdu = ResponseApdu::from_bytes(vec![0xDE, 0xAD, 0x90, 0x00]).unwrap();
         assert_eq!(ffi_apdu.sw(), 0x9000);
         assert_eq!(ffi_apdu.data(), vec![0xDE, 0xAD]);
-        assert_eq!(ffi_apdu.to_vec(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
+        assert_eq!(ffi_apdu.to_vec(), FfiVecOfU8::from_nonzeroizing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
     }
 
     #[test]
@@ -345,7 +345,7 @@ mod tests {
         let response = ResponseApdu::from_parts(0x9000, vec![0xDE, 0xAD]).unwrap();
         assert_eq!(response.sw(), 0x9000);
         assert_eq!(response.data(), vec![0xDE, 0xAD]);
-        assert_eq!(response.to_vec(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
+        assert_eq!(response.to_vec(), FfiVecOfU8::from_nonzeroizing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
     }
 
     #[test]

--- a/core-modules/healthcard/src/ffi/channel.rs
+++ b/core-modules/healthcard/src/ffi/channel.rs
@@ -22,6 +22,8 @@
 use crate::command::apdu::{ApduError, CardCommandApdu, CardResponseApdu};
 use crate::exchange::channel::CardChannel as CoreCardChannel;
 use crate::exchange::ExchangeError;
+use crate::ffi::maybe_zeroing_vec::VecOfU8 as FfiVecOfU8;
+use asn1::maybe_zeroing_vec::VecOfU8 as Asn1VecOfU8;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 
@@ -99,7 +101,9 @@ impl CommandApdu {
         length_class: crate::command::apdu::LengthClass,
         data: Vec<u8>,
     ) -> Result<Self, ApduError> {
-        Ok(Self { inner: CardCommandApdu::with_data(cla, ins, p1, p2, length_class, data)? })
+        Ok(Self {
+            inner: CardCommandApdu::with_data(cla, ins, p1, p2, length_class, Asn1VecOfU8::new_zeroizing(data))?,
+        })
     }
 
     /// Creates an APDU with command data (`Lc` + data) and an expected response length (`Le`).
@@ -118,13 +122,21 @@ impl CommandApdu {
         let expected_length = usize::try_from(expected_length)
             .map_err(|_| ApduError::InvalidLength("expected_length is too large".into()))?;
         Ok(Self {
-            inner: CardCommandApdu::with_data_and_expect(cla, ins, p1, p2, length_class, data, expected_length)?,
+            inner: CardCommandApdu::with_data_and_expect(
+                cla,
+                ins,
+                p1,
+                p2,
+                length_class,
+                Asn1VecOfU8::new_zeroizing(data),
+                expected_length,
+            )?,
         })
     }
 
     /// Serializes the command APDU to raw bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.inner.to_bytes()
+    pub fn to_bytes(&self) -> Arc<FfiVecOfU8> {
+        FfiVecOfU8::from_core(self.inner.to_bytes())
     }
 }
 
@@ -191,8 +203,8 @@ impl ResponseApdu {
     }
 
     /// Serializes the response APDU to raw bytes (`data || SW1 || SW2`).
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.inner.to_bytes()
+    pub fn to_bytes(&self) -> Arc<FfiVecOfU8> {
+        FfiVecOfU8::from_core(self.inner.to_bytes())
     }
 }
 
@@ -289,6 +301,7 @@ impl From<CardChannelError> for ExchangeError {
 mod tests {
     use super::*;
     use crate::command::apdu::{CardCommandApdu, EXPECTED_LENGTH_WILDCARD_EXTENDED};
+    use crate::ffi::maybe_zeroing_vec::VecOfU8 as FfiVecOfU8;
 
     #[test]
     fn command_apdu_roundtrip() {
@@ -325,7 +338,7 @@ mod tests {
         let ffi_apdu = ResponseApdu::from_bytes(vec![0xDE, 0xAD, 0x90, 0x00]).unwrap();
         assert_eq!(ffi_apdu.sw(), 0x9000);
         assert_eq!(ffi_apdu.data(), vec![0xDE, 0xAD]);
-        assert_eq!(ffi_apdu.to_bytes(), vec![0xDE, 0xAD, 0x90, 0x00]);
+        assert_eq!(ffi_apdu.to_bytes(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
     }
 
     #[test]
@@ -333,7 +346,7 @@ mod tests {
         let response = ResponseApdu::from_parts(0x9000, vec![0xDE, 0xAD]).unwrap();
         assert_eq!(response.sw(), 0x9000);
         assert_eq!(response.data(), vec![0xDE, 0xAD]);
-        assert_eq!(response.to_bytes(), vec![0xDE, 0xAD, 0x90, 0x00]);
+        assert_eq!(response.to_bytes(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
     }
 
     #[test]

--- a/core-modules/healthcard/src/ffi/channel.rs
+++ b/core-modules/healthcard/src/ffi/channel.rs
@@ -136,7 +136,7 @@ impl CommandApdu {
 
     /// Serializes the command APDU to raw bytes.
     pub fn to_bytes(&self) -> Arc<FfiVecOfU8> {
-        FfiVecOfU8::from_core(self.inner.to_bytes())
+        FfiVecOfU8::from_core(self.inner.to_vec())
     }
 }
 
@@ -189,7 +189,7 @@ impl ResponseApdu {
         let mut full = data;
         full.push((sw >> 8) as u8);
         full.push(sw as u8);
-        Ok(ResponseApdu { inner: CardResponseApdu::new(&full)? })
+        Ok(ResponseApdu { inner: CardResponseApdu::new_nonzeroing(&full)? })
     }
 
     /// Returns the status word (SW1SW2) as `0xSW1SW2` (big-endian).
@@ -204,7 +204,7 @@ impl ResponseApdu {
 
     /// Serializes the response APDU to raw bytes (`data || SW1 || SW2`).
     pub fn to_bytes(&self) -> Arc<FfiVecOfU8> {
-        FfiVecOfU8::from_core(self.inner.to_bytes())
+        FfiVecOfU8::from_core(self.inner.to_vec())
     }
 }
 
@@ -307,7 +307,7 @@ mod tests {
     fn command_apdu_roundtrip() {
         let ffi_apdu = CommandApdu::header_only(0x00, 0xA4, 0x04, 0x00).unwrap();
         let rebuilt = ffi_apdu.to_core();
-        assert_eq!(rebuilt.to_bytes(), CardCommandApdu::header_only(0x00, 0xA4, 0x04, 0x00).unwrap().to_bytes());
+        assert_eq!(rebuilt.to_vec(), CardCommandApdu::header_only(0x00, 0xA4, 0x04, 0x00).unwrap().to_vec());
     }
 
     #[test]
@@ -326,10 +326,10 @@ mod tests {
 
     #[test]
     fn response_apdu_conversion_preserves_bytes() {
-        let response = CardResponseApdu::new(&[0xDE, 0xAD, 0x90, 0x00]).unwrap();
+        let response = CardResponseApdu::new_nonzeroing(&[0xDE, 0xAD, 0x90, 0x00]).unwrap();
         let ffi_apdu = ResponseApdu::from_core(response.clone());
         let rebuilt = CardResponseApdu::try_from(ffi_apdu.as_ref()).unwrap();
-        assert_eq!(rebuilt.to_bytes(), response.to_bytes());
+        assert_eq!(rebuilt.to_vec(), response.to_vec());
         assert_eq!(ffi_apdu.sw(), 0x9000);
     }
 

--- a/core-modules/healthcard/src/ffi/channel.rs
+++ b/core-modules/healthcard/src/ffi/channel.rs
@@ -134,8 +134,7 @@ impl CommandApdu {
         })
     }
 
-    /// Serializes the command APDU to raw bytes.
-    pub fn to_bytes(&self) -> Arc<FfiVecOfU8> {
+    pub fn to_vec(&self) -> Arc<FfiVecOfU8> {
         FfiVecOfU8::from_core(self.inner.to_vec())
     }
 }
@@ -145,7 +144,7 @@ impl CommandApdu {
 /// This object represents a response APDU and exposes:
 /// - `sw()`: status word (SW1SW2)
 /// - `data()`: response data without the status word
-/// - `to_bytes()`: raw APDU bytes (`data || SW1 || SW2`)
+/// - `to_vec()`: raw APDU bytes (`data || SW1 || SW2`)
 #[derive(Debug, uniffi::Object)]
 pub struct ResponseApdu {
     inner: CardResponseApdu,
@@ -203,7 +202,7 @@ impl ResponseApdu {
     }
 
     /// Serializes the response APDU to raw bytes (`data || SW1 || SW2`).
-    pub fn to_bytes(&self) -> Arc<FfiVecOfU8> {
+    pub fn to_vec(&self) -> Arc<FfiVecOfU8> {
         FfiVecOfU8::from_core(self.inner.to_vec())
     }
 }
@@ -338,7 +337,7 @@ mod tests {
         let ffi_apdu = ResponseApdu::from_bytes(vec![0xDE, 0xAD, 0x90, 0x00]).unwrap();
         assert_eq!(ffi_apdu.sw(), 0x9000);
         assert_eq!(ffi_apdu.data(), vec![0xDE, 0xAD]);
-        assert_eq!(ffi_apdu.to_bytes(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
+        assert_eq!(ffi_apdu.to_vec(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
     }
 
     #[test]
@@ -346,7 +345,7 @@ mod tests {
         let response = ResponseApdu::from_parts(0x9000, vec![0xDE, 0xAD]).unwrap();
         assert_eq!(response.sw(), 0x9000);
         assert_eq!(response.data(), vec![0xDE, 0xAD]);
-        assert_eq!(response.to_bytes(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
+        assert_eq!(response.to_vec(), FfiVecOfU8::from_nonzeroing_bytes(vec![0xDE, 0xAD, 0x90, 0x00]));
     }
 
     #[test]

--- a/core-modules/healthcard/src/ffi/exchange.rs
+++ b/core-modules/healthcard/src/ffi/exchange.rs
@@ -273,7 +273,7 @@ mod tests {
     use std::sync::Arc;
 
     fn response(status: HealthCardResponseStatus) -> CoreHealthCardResponse {
-        let apdu = CardResponseApdu::new(&[0x90, 0x00]).unwrap();
+        let apdu = CardResponseApdu::new_nonzeroing(&[0x90, 0x00]).unwrap();
         CoreHealthCardResponse::new(status, apdu)
     }
 

--- a/core-modules/healthcard/src/ffi/exchange.rs
+++ b/core-modules/healthcard/src/ffi/exchange.rs
@@ -273,7 +273,7 @@ mod tests {
     use std::sync::Arc;
 
     fn response(status: HealthCardResponseStatus) -> CoreHealthCardResponse {
-        let apdu = CardResponseApdu::new_nonzeroing(&[0x90, 0x00]).unwrap();
+        let apdu = CardResponseApdu::new_nonzeroizing(&[0x90, 0x00]).unwrap();
         CoreHealthCardResponse::new(status, apdu)
     }
 

--- a/core-modules/healthcard/src/ffi/maybe_zeroing_vec.rs
+++ b/core-modules/healthcard/src/ffi/maybe_zeroing_vec.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 - 2026 gematik GmbH
+// SPDX-FileCopyrightText: Copyright 2026 gematik GmbH
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,11 +18,30 @@
 //
 // For additional notes and disclaimer from gematik and in case of changes by gematik,
 // find details in the "Readme" file.
-pub mod cv_certificate;
-pub mod date_time;
-pub mod decoder;
-pub mod encoder;
-pub mod error;
-pub mod maybe_zeroing_vec;
-pub mod oid;
-pub mod tag;
+
+use asn1::maybe_zeroing_vec::VecOfU8 as Asn1VecOfU8;
+use std::sync::Arc;
+
+/// a wrapped Vec<u8> that might be zeroized (depending on it's configuration)
+#[derive(uniffi::Object, Debug, PartialEq, Eq)]
+pub struct VecOfU8 {
+    inner: Asn1VecOfU8,
+}
+
+impl VecOfU8 {
+    pub(crate) fn from_core(inner: Asn1VecOfU8) -> Arc<Self> {
+        Arc::new(Self { inner })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn from_nonzeroing_bytes(bytes: Vec<u8>) -> Arc<Self> {
+        Arc::new(Self { inner: Asn1VecOfU8::new_nonzeroizing(bytes) })
+    }
+}
+
+#[uniffi::export]
+impl VecOfU8 {
+    pub fn clone_as_nonzeroizing_vec(&self) -> Vec<u8> {
+        self.inner.as_ref().to_vec()
+    }
+}

--- a/core-modules/healthcard/src/ffi/maybe_zeroizing_vec.rs
+++ b/core-modules/healthcard/src/ffi/maybe_zeroizing_vec.rs
@@ -19,7 +19,7 @@
 // For additional notes and disclaimer from gematik and in case of changes by gematik,
 // find details in the "Readme" file.
 
-use asn1::maybe_zeroing_vec::VecOfU8 as Asn1VecOfU8;
+use asn1::maybe_zeroizing_vec::VecOfU8 as Asn1VecOfU8;
 use std::sync::Arc;
 
 /// a wrapped Vec<u8> that might be zeroized (depending on it's configuration)
@@ -34,7 +34,7 @@ impl VecOfU8 {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn from_nonzeroing_bytes(bytes: Vec<u8>) -> Arc<Self> {
+    pub(crate) fn from_nonzeroizing_bytes(bytes: Vec<u8>) -> Arc<Self> {
         Arc::new(Self { inner: Asn1VecOfU8::new_nonzeroizing(bytes) })
     }
 }

--- a/core-modules/healthcard/src/ffi/mod.rs
+++ b/core-modules/healthcard/src/ffi/mod.rs
@@ -29,4 +29,5 @@
 
 mod channel;
 mod exchange;
+pub mod maybe_zeroing_vec;
 mod secure_channel;

--- a/core-modules/healthcard/src/ffi/mod.rs
+++ b/core-modules/healthcard/src/ffi/mod.rs
@@ -29,5 +29,5 @@
 
 mod channel;
 mod exchange;
-pub mod maybe_zeroing_vec;
+pub mod maybe_zeroizing_vec;
 mod secure_channel;

--- a/core-modules/healthcard/tests/exchange_replay.rs
+++ b/core-modules/healthcard/tests/exchange_replay.rs
@@ -47,12 +47,12 @@ impl CardChannel for ReplayChannel {
     }
 
     fn transmit(&mut self, command: &CardCommandApdu) -> Result<CardResponseApdu, Self::Error> {
-        let tx = command.to_bytes();
+        let tx = command.to_vec();
         let rx = self
             .session
             .transmit_bytes(&tx)
             .map_err(|err| ExchangeError::Transport { code: 0, message: err.to_string() })?;
-        CardResponseApdu::new(&rx).map_err(ExchangeError::from)
+        CardResponseApdu::new_nonzeroing(&rx).map_err(ExchangeError::from)
     }
 }
 

--- a/core-modules/healthcard/tests/exchange_replay.rs
+++ b/core-modules/healthcard/tests/exchange_replay.rs
@@ -52,7 +52,7 @@ impl CardChannel for ReplayChannel {
             .session
             .transmit_bytes(&tx)
             .map_err(|err| ExchangeError::Transport { code: 0, message: err.to_string() })?;
-        CardResponseApdu::new_nonzeroing(&rx).map_err(ExchangeError::from)
+        CardResponseApdu::new_nonzeroizing(&rx).map_err(ExchangeError::from)
     }
 }
 


### PR DESCRIPTION
support for zeroizing datatype VecOfU8.
Please check during review if throughout the code the appropriate variant of VecOfU8 is used!
Zeroizing is more secure but takes additional time (because its memory will be overriden by 0s on Drop).
NonZeroizing is less secure but faster.

## Changes
- introduces a new VecOfU8 enum with two variants Zeroizing and NonZeroizing which is used in many places instead of a Vec<u8>
- if VecOfU8::Zeroizing is used it's underlying Vec<u8> is zeroed on drop
- the Asn1Encoder now contains two write-functions (instead of one retrning a Vec<u8>), one returning a VecOfU8::Zeroizing and one returning a VecOfU8::NonZeroizing

## Breaking Changes
<!-- API/behavior changes that require downstream updates. -->
- ffi/channel.rs -> ResponseApdu.to_bytes(&self) now returns a Arc<FfiVecOfU8>
- renamed CardResponseApdu::new to CardResponseApdu::new_nonzeroing.
- renamed Apdu::to_bytes() to Apdu::to_vec()

## Checklist
- [ ] Tests added/updated where appropriate
- [ ] FFI targets (swift, kotlin, ...) are updated where appropriate
- [ ] Public API is documented
- [ ] Docs updated (`docs/`, `README.md`) if needed
- [ ] Release notes updated (`ReleaseNotes.md`) if user-facing change
