### PR TITLE
Open-126: Add Swift and Kotlin Binding Test Runs to CI/CD Workflow

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   branch_naming:
     name: Branch naming
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 5
     steps:
       - name: Validate branch name
@@ -74,7 +74,7 @@ jobs:
 
   license_compliance:
     name: License compliance
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: branch_naming
     timeout-minutes: 10
     steps:
@@ -88,7 +88,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: branch_naming
     timeout-minutes: 30
     steps:
@@ -114,7 +114,7 @@ jobs:
 
   coverage:
     name: Quality report (coverage)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: branch_naming
     timeout-minutes: 45
     steps:

--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -151,6 +151,19 @@ jobs:
         run: |
           just kotlin-bindings-generate-android
 
+      - name: Run Kotlin binding tests (Linux or macOS)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          cd ${{ env.OUT_ROOT }}/kotlin
+          ../../../../core-modules-kotlin/gradlew test --no-daemon
+
+      - name: Run Kotlin binding tests (Windows only)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cd $env:OUT_ROOT\kotlin
+          ..\..\..\..\core-modules-kotlin\gradlew.bat test --no-daemon
+
       - name: Upload OpenSSL Configure logs (on failure)
         if: failure()
         uses: actions/upload-artifact@v7
@@ -201,6 +214,11 @@ jobs:
 
       - name: Build XCFramework
         run: just swift-xcframework
+
+      - name: Run Swift binding tests
+        run: |
+          cd core-modules-swift/healthcard
+          xcodebuild test -scheme OpenHealthHealthcardFFI -destination 'platform=macOS'
 
       - name: Stage Swift wrapper for release
         run: cp core-modules-swift/healthcard/Sources/OpenHealthHealthcard/OpenHealthHealthcard.swift OpenHealthHealthcard.swift


### PR DESCRIPTION
OPEN-126: Add Swift and Kotlin Binding Test Runs to CI/CD Workflow

## Changes
- ci-rust.yml: so that MacOSX runner is used for CI workflow (instead of Ubuntu runner)
- release-bindings.yml: so that 
1) Add Kotlin and Swift binding tests executions (see release workflow release-bindings.yml) 
2) Executing the KMP modules requires Android (see release workflow)
3) Add caching for the Kotlin world

## Breaking Changes
- None

## Checklist
- [ ] Tests added/updated where appropriate
- [ ] FFI targets (swift, kotlin, ...) are updated where appropriate
- [ ] Public API is documented
- [ ] Docs updated (`docs/`, `README.md`) if needed
- [ ] Release notes updated (`ReleaseNotes.md`) if user-facing change
