### PR TITLE
Open-126: Add Swift and Kotlin Binding Test Runs to CI/CD Workflow

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -95,36 +95,47 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ runner.os }}-rust
+
       - name: Install toolchains
         run: |
           rustup component add clippy
           rustup toolchain install nightly --profile minimal --component rustfmt
+
       - name: Check formatting
         run: cargo +nightly fmt --all -- --check
+
       - name: Lint with clippy
         run: cargo clippy --workspace --all-targets --no-default-features --features ci -- -D warnings
+
       - name: Build
         run: cargo build --workspace --no-default-features --features ci --locked --verbose
+
       - name: Run tests
         run: cargo test --workspace --no-default-features --features ci --locked --verbose
+
       - name: Ensure Android SDK platforms
         run: |
           yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null || true
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" "platforms;android-34" "build-tools;34.0.0"
+
       - name: Install cargo-ndk
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-ndk
+
       - name: Add Rust Android targets
         run: rustup target add aarch64-linux-android aarch64-apple-darwin x86_64-linux-android
+
       - name: Install just
         uses: taiki-e/install-action@v2
         with:
           tool: just
+
       - name: Build Kotlin bindings
         run: |
           just kotlin-bindings-generate darwin aarch64 libhealthcard.dylib release
@@ -135,7 +146,9 @@ jobs:
 
       - name: Run Kotlin binding tests
         run: |
-          ./core-modules-kotlin/gradlew test --no-daemon
+          cd ./core-modules-kotlin/
+          ./gradlew test --no-daemon
+
       - name: Build XCFramework
         run: just swift-xcframework
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -129,7 +129,7 @@ jobs:
           tool: cargo-ndk
 
       - name: Add Rust Android targets
-        run: rustup target add aarch64-linux-android aarch64-apple-darwin x86_64-linux-android
+        run: rustup target add aarch64-linux-android aarch64-apple-darwin x86_64-linux-android aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios x86_64-apple-darwin
 
       - name: Install just
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   branch_naming:
     name: Branch naming
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 5
     steps:
       - name: Validate branch name
@@ -88,7 +88,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: branch_naming
     timeout-minutes: 30
     steps:
@@ -114,7 +114,7 @@ jobs:
 
   coverage:
     name: Quality report (coverage)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: branch_naming
     timeout-minutes: 45
     steps:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   branch_naming:
     name: Branch naming
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Validate branch name
@@ -88,7 +88,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: branch_naming
     timeout-minutes: 30
     steps:
@@ -115,35 +115,37 @@ jobs:
         run: |
           yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null || true
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" "platforms;android-34" "build-tools;34.0.0"
-      - name: Install cargo-ndk (Linux only)
+      - name: Install cargo-ndk
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-ndk
-      - name: Add Rust Android targets (Linux only)
-        run: rustup target add aarch64-linux-android x86_64-linux-android
+      - name: Add Rust Android targets
+        run: rustup target add aarch64-linux-android aarch64-apple-darwin
       - name: Install just
         uses: taiki-e/install-action@v2
         with:
           tool: just
       - name: Build Kotlin bindings
         run: |
-          if [ -n "${{ matrix.just_shell }}" ]; then
-            just --shell="${{ matrix.just_shell }}" kotlin-bindings-generate ${{ matrix.platform }} ${{ matrix.arch }} ${{ matrix.library_file }} release
-          else
-            just kotlin-bindings-generate ${{ matrix.platform }} ${{ matrix.arch }} ${{ matrix.library_file }} release
-          fi
+          just kotlin-bindings-generate darwin aarch64 libhealthcard.dylib release
 
-      - name: Build Android native libraries (Linux only - arm64-v8a, x86_64)
+      - name: Build Android native libraries
         run: |
           just kotlin-bindings-generate-android
 
-      - name: Run Kotlin binding tests (Linux or macOS)
+      - name: Run Kotlin binding tests
         run: |
           ./core-modules-kotlin/gradlew test --no-daemon
+      - name: Build XCFramework
+        run: just swift-xcframework
+
+      - name: Run Swift binding tests
+        run: |
+          swift test
 
   coverage:
     name: Quality report (coverage)
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: branch_naming
     timeout-minutes: 45
     steps:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -121,6 +121,10 @@ jobs:
           tool: cargo-ndk
       - name: Add Rust Android targets (Linux only)
         run: rustup target add aarch64-linux-android x86_64-linux-android
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
       - name: Build Kotlin bindings
         run: |
           if [ -n "${{ matrix.just_shell }}" ]; then

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           tool: cargo-ndk
       - name: Add Rust Android targets
-        run: rustup target add aarch64-linux-android aarch64-apple-darwin
+        run: rustup target add aarch64-linux-android aarch64-apple-darwin x86_64-linux-android
       - name: Install just
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -88,7 +88,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: branch_naming
     timeout-minutes: 30
     steps:
@@ -111,26 +111,31 @@ jobs:
         run: cargo build --workspace --no-default-features --features ci --locked --verbose
       - name: Run tests
         run: cargo test --workspace --no-default-features --features ci --locked --verbose
-      - name: Ensure Android SDK platforms (Linux only)
-        if: runner.os == 'Linux'
-        env:
-          ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
+      - name: Ensure Android SDK platforms
         run: |
           yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null || true
           "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" "platforms;android-34" "build-tools;34.0.0"
       - name: Install cargo-ndk (Linux only)
-        if: runner.os == 'Linux'
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-ndk
       - name: Add Rust Android targets (Linux only)
-        if: runner.os == 'Linux'
         run: rustup target add aarch64-linux-android x86_64-linux-android
-      - name: Run Kotlin binding tests
-        if: runner.os == 'Linux'
+      - name: Build Kotlin bindings
         run: |
-          cd core-modules-kotlin
-          ./gradlew test --no-daemon
+          if [ -n "${{ matrix.just_shell }}" ]; then
+            just --shell="${{ matrix.just_shell }}" kotlin-bindings-generate ${{ matrix.platform }} ${{ matrix.arch }} ${{ matrix.library_file }} release
+          else
+            just kotlin-bindings-generate ${{ matrix.platform }} ${{ matrix.arch }} ${{ matrix.library_file }} release
+          fi
+
+      - name: Build Android native libraries (Linux only - arm64-v8a, x86_64)
+        run: |
+          just kotlin-bindings-generate-android
+
+      - name: Run Kotlin binding tests (Linux or macOS)
+        run: |
+          ./core-modules-kotlin/gradlew test --no-daemon
 
   coverage:
     name: Quality report (coverage)

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -88,7 +88,7 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: branch_naming
     timeout-minutes: 30
     steps:
@@ -111,6 +111,26 @@ jobs:
         run: cargo build --workspace --no-default-features --features ci --locked --verbose
       - name: Run tests
         run: cargo test --workspace --no-default-features --features ci --locked --verbose
+      - name: Ensure Android SDK platforms (Linux only)
+        if: runner.os == 'Linux'
+        env:
+          ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
+        run: |
+          yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null || true
+          "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --sdk_root="${ANDROID_SDK_ROOT}" "platforms;android-34" "build-tools;34.0.0"
+      - name: Install cargo-ndk (Linux only)
+        if: runner.os == 'Linux'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+      - name: Add Rust Android targets (Linux only)
+        if: runner.os == 'Linux'
+        run: rustup target add aarch64-linux-android x86_64-linux-android
+      - name: Run Kotlin binding tests
+        if: runner.os == 'Linux'
+        run: |
+          cd core-modules-kotlin
+          ./gradlew test --no-daemon
 
   coverage:
     name: Quality report (coverage)

--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -151,6 +151,19 @@ jobs:
         run: |
           just kotlin-bindings-generate-android
 
+      - name: Run Kotlin binding tests (Linux or macOS)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          cd ${{ env.OUT_ROOT }}/kotlin
+          ../../../../core-modules-kotlin/gradlew test --no-daemon
+
+      - name: Run Kotlin binding tests (Windows only)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cd $env:OUT_ROOT\kotlin
+          ..\..\..\..\core-modules-kotlin\gradlew.bat test --no-daemon
+
       - name: Upload OpenSSL Configure logs (on failure)
         if: failure()
         uses: actions/upload-artifact@v7
@@ -201,6 +214,11 @@ jobs:
 
       - name: Build XCFramework
         run: just swift-xcframework
+
+      - name: Run Swift binding tests
+        run: |
+          cd core-modules-swift/healthcard
+          xcodebuild test -scheme OpenHealthHealthcardFFI -destination 'platform=macOS'
 
       - name: Stage Swift wrapper for release
         run: cp core-modules-swift/healthcard/Sources/OpenHealthHealthcard/OpenHealthHealthcard.swift OpenHealthHealthcard.swift

--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -154,15 +154,13 @@ jobs:
       - name: Run Kotlin binding tests (Linux or macOS)
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
-          cd ${{ env.OUT_ROOT }}/kotlin
-          ../../../../core-modules-kotlin/gradlew test --no-daemon
+          ./core-modules-kotlin/gradlew test --no-daemon
 
       - name: Run Kotlin binding tests (Windows only)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          cd $env:OUT_ROOT\kotlin
-          ..\..\..\..\core-modules-kotlin\gradlew.bat test --no-daemon
+          .\core-modules-kotlin\gradlew.bat test --no-daemon
 
       - name: Upload OpenSSL Configure logs (on failure)
         if: failure()
@@ -217,8 +215,7 @@ jobs:
 
       - name: Run Swift binding tests
         run: |
-          cd core-modules-swift/healthcard
-          xcodebuild test -scheme OpenHealthHealthcardFFI -destination 'platform=macOS'
+          swift test
 
       - name: Stage Swift wrapper for release
         run: cp core-modules-swift/healthcard/Sources/OpenHealthHealthcard/OpenHealthHealthcard.swift OpenHealthHealthcard.swift


### PR DESCRIPTION
OPEN-126: Add Swift and Kotlin Binding Test Runs to CI/CD Workflow

## Changes
- ci-rust.yml: so that MacOSX runner is used for CI workflow (instead of Ubuntu runner, license_compliance is only available on ubuntu though)
- release-bindings.yml: so that 
1) Add Kotlin and Swift binding tests executions (see release workflow release-bindings.yml) 
2) Executing the KMP modules requires Android (see release workflow)
3) Add caching for the Kotlin world

## Breaking Changes
- None

## Checklist
- [ ] Tests added/updated where appropriate
- [ ] FFI targets (swift, kotlin, ...) are updated where appropriate
- [ ] Public API is documented
- [ ] Docs updated (`docs/`, `README.md`) if needed
- [ ] Release notes updated (`ReleaseNotes.md`) if user-facing change
