### PR TITLE
OPEN-00: Update release notes for 0.2.0-alpha1

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -29,11 +29,18 @@ This document summarizes the publicly released versions of OpenHealth Core.
 
 ### 0.2.0 (Upcoming)
 
+This release captures the changes since `0.2.0-alpha1`.
+
+No changes documented yet.
+
+### 0.2.0-alpha1
+
 This release captures the changes since `0.1.1-alpha1`.
 
 Added
 - ASN.1 UniFFI bindings with dedicated Kotlin and Swift modules, including generated host/mobile packaging for `asn1` alongside `healthcard` ([#66](https://github.com/gematik/OpenHealth-Core/pull/66)).
 - Additional FFI surface for healthcard exchange-layer operations such as certificate retrieval, random exchange, PACE-related flows, and PIN handling ([#47](https://github.com/gematik/OpenHealth-Core/pull/47)).
+- Additional APDU command builders, ELC helper flows, and matching JVM facades for healthcard operations ([#62](https://github.com/gematik/OpenHealth-Core/pull/62)).
 - Zeroizing support for ASN.1 encoder buffers via the new `VecOfU8`/`ZeroizingOption` path ([#55](https://github.com/gematik/OpenHealth-Core/pull/55)).
 - CodeQL analysis workflow and expanded Rust coverage quality gates ([#53](https://github.com/gematik/OpenHealth-Core/pull/53), [#57](https://github.com/gematik/OpenHealth-Core/pull/57), [#58](https://github.com/gematik/OpenHealth-Core/pull/58)).
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -40,7 +40,7 @@ This release captures the changes since `0.1.1-alpha1`.
 Added
 - ASN.1 UniFFI bindings with dedicated Kotlin and Swift modules, including generated host/mobile packaging for `asn1` alongside `healthcard` ([#66](https://github.com/gematik/OpenHealth-Core/pull/66)).
 - Additional FFI surface for healthcard exchange-layer operations such as certificate retrieval, random exchange, PACE-related flows, and PIN handling ([#47](https://github.com/gematik/OpenHealth-Core/pull/47)).
-- Additional APDU command builders, ELC helper flows, and matching JVM facades for healthcard operations ([#62](https://github.com/gematik/OpenHealth-Core/pull/62)).
+- Additional APDU command builders and ELC helper flows for healthcard operations ([#62](https://github.com/gematik/OpenHealth-Core/pull/62)).
 - Zeroizing support for ASN.1 encoder buffers via the new `VecOfU8`/`ZeroizingOption` path ([#55](https://github.com/gematik/OpenHealth-Core/pull/55)).
 - CodeQL analysis workflow and expanded Rust coverage quality gates ([#53](https://github.com/gematik/OpenHealth-Core/pull/53), [#57](https://github.com/gematik/OpenHealth-Core/pull/57), [#58](https://github.com/gematik/OpenHealth-Core/pull/58)).
 


### PR DESCRIPTION
## Summary
- add a dedicated `0.2.0-alpha1` section to capture the prepared release notes
- add the missing APDU, ELC helper, and JVM facade entry from recent commits
- keep a new `0.2.0 (Upcoming)` section at the top for follow-up changes

## Testing
- Not run (not requested)