### PR TITLE
OPEN-00: Add crypto module to release bindings workflow

### DIFF
--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build Kotlin host bindings
         run: |
-          for module in healthcard asn1; do
+          for module in healthcard asn1 crypto; do
             case "${module}" in
               healthcard)
                 library_file="libhealthcard.so"
@@ -162,6 +162,14 @@ jobs:
                   library_file="asn1.dll"
                 elif [ "${{ matrix.platform }}" = "darwin" ]; then
                   library_file="libasn1.dylib"
+                fi
+                ;;
+              crypto)
+                library_file="libcrypto.so"
+                if [ "${{ matrix.platform }}" = "windows" ]; then
+                  library_file="crypto.dll"
+                elif [ "${{ matrix.platform }}" = "darwin" ]; then
+                  library_file="libcrypto.dylib"
                 fi
                 ;;
               *)
@@ -185,7 +193,7 @@ jobs:
       - name: Build Android native libraries (Linux x64 only)
         if: matrix.build_android
         run: |
-          for module in healthcard asn1; do
+          for module in healthcard asn1 crypto; do
             out_root="${OUT_ROOT_BASE}/${module}/${{ matrix.display_name }}/generated/uniffi"
             OUT_ROOT="${out_root}" just kotlin-bindings-generate-android "${module}"
           done
@@ -218,6 +226,16 @@ jobs:
             ${{ github.workspace }}/artifacts/asn1/${{ matrix.display_name }}/generated/uniffi/resources/**
             ${{ github.workspace }}/artifacts/asn1/${{ matrix.display_name }}/generated/uniffi/kotlin/**
             ${{ github.workspace }}/artifacts/asn1/${{ matrix.display_name }}/generated/uniffi/android-jni/**
+          if-no-files-found: warn
+
+      - name: Upload Kotlin resources (crypto)
+        uses: actions/upload-artifact@v7
+        with:
+          name: kotlin-crypto-bindings-${{ matrix.display_name }}
+          path: |
+            ${{ github.workspace }}/artifacts/crypto/${{ matrix.display_name }}/generated/uniffi/resources/**
+            ${{ github.workspace }}/artifacts/crypto/${{ matrix.display_name }}/generated/uniffi/kotlin/**
+            ${{ github.workspace }}/artifacts/crypto/${{ matrix.display_name }}/generated/uniffi/android-jni/**
           if-no-files-found: warn
 
   swift-xcframework:
@@ -362,10 +380,17 @@ jobs:
           pattern: "kotlin-asn1-bindings-*"
           path: assembly/input/asn1
 
-      - name: Collect libraries and generated Kotlin (healthcard + asn1)
+      - name: Download crypto platform artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: "kotlin-crypto-bindings-*"
+          path: assembly/input/crypto
+
+      - name: Collect libraries and generated Kotlin (healthcard + asn1 + crypto)
         run: |
           just kotlin-bindings-assemble assembly/input/healthcard assembly/dist/healthcard/generated/uniffi
           just kotlin-bindings-assemble assembly/input/asn1 assembly/dist/asn1/generated/uniffi
+          just kotlin-bindings-assemble assembly/input/crypto assembly/dist/crypto/generated/uniffi
 
       - name: Upload Kotlin bindings bundle (healthcard)
         uses: actions/upload-artifact@v7
@@ -387,6 +412,16 @@ jobs:
             assembly/dist/asn1/generated/uniffi/android-jni/**
           if-no-files-found: error
 
+      - name: Upload Kotlin bindings bundle (crypto)
+        uses: actions/upload-artifact@v7
+        with:
+          name: kotlin-crypto-bindings-bundle
+          path: |
+            assembly/dist/crypto/generated/uniffi/resources/**
+            assembly/dist/crypto/generated/uniffi/kotlin/**
+            assembly/dist/crypto/generated/uniffi/android-jni/**
+          if-no-files-found: error
+
       - name: Publish Kotlin bindings to mavenLocal (assembled outputs)
         run: |
           if [ -n "${{ inputs.version }}" ]; then
@@ -394,6 +429,7 @@ jobs:
           fi
           OUT_ROOT="${GITHUB_WORKSPACE}/assembly/dist/healthcard/generated/uniffi" just kotlin-publish-local healthcard
           OUT_ROOT="${GITHUB_WORKSPACE}/assembly/dist/asn1/generated/uniffi" just kotlin-publish-local asn1
+          OUT_ROOT="${GITHUB_WORKSPACE}/assembly/dist/crypto/generated/uniffi" just kotlin-publish-local crypto
 
       - name: Stage Maven local artifacts for upload
         run: |


### PR DESCRIPTION
## Summary
- include `crypto` in the Kotlin host bindings release workflow
- add `crypto` Android/native artifact generation and upload steps
- assemble and publish `crypto` bindings alongside `healthcard` and `asn1`

## Testing
- Not run (not requested)