### PR TITLE
OPEN-130: Add CVC chain validation and ASN.1 source spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "base64",
+ "chrono",
  "crypto-openssl-sys",
  "hex",
  "num-bigint",

--- a/core-modules/asn1/src/cv_certificate.rs
+++ b/core-modules/asn1/src/cv_certificate.rs
@@ -34,9 +34,12 @@
 //! - Dates are encoded as 6 digits (`YYMMDD`), where each digit is stored in a single octet with
 //!   value `0..=9` (not ASCII).
 
+use std::ops::{Deref, DerefMut};
+
 use crate::decoder::{Asn1Decoder, Asn1Length, ParserScope};
 use crate::error::{Asn1DecoderError, Asn1DecoderResult};
 use crate::oid::ObjectIdentifier;
+use crate::source::{Asn1Source, Asn1Span, Spanned};
 use crate::tag::{Asn1Id, TagNumberExt};
 
 const TAG_CV_CERTIFICATE: u32 = 33;
@@ -61,7 +64,8 @@ const MAX_CERT_FIELD_LEN: usize = 65_535;
 /// performed).
 pub struct CVCertificate {
     pub body: CertificateBody,
-    pub signature: Vec<u8>,
+    pub signature: CVCertSignature,
+    source: Asn1Source,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,6 +83,7 @@ pub struct CertificateBody {
     pub certificate_effective_date: CertificateDate,
     pub certificate_expiration_date: CertificateDate,
     pub certificate_extensions: Option<CertificateExtensions>,
+    source_span: Asn1Span,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,6 +95,70 @@ pub struct CVCertPublicKey {
     pub key_oid: ObjectIdentifier,
     /// Raw contents after the key OID (context-specific key data objects).
     pub key_data: Vec<u8>,
+    source_span: Asn1Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Raw CVC signature content octets.
+pub struct CVCertSignature {
+    value: Vec<u8>,
+    source_span: Asn1Span,
+}
+
+impl CVCertSignature {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.value
+    }
+
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        &mut self.value
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.value.clone()
+    }
+
+    pub fn source_span(&self) -> Asn1Span {
+        self.source_span
+    }
+}
+
+impl Deref for CVCertSignature {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_bytes()
+    }
+}
+
+impl DerefMut for CVCertSignature {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_bytes()
+    }
+}
+
+impl PartialEq<Vec<u8>> for CVCertSignature {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_bytes() == other.as_slice()
+    }
+}
+
+impl PartialEq<CVCertSignature> for Vec<u8> {
+    fn eq(&self, other: &CVCertSignature) -> bool {
+        self.as_slice() == other.as_bytes()
+    }
+}
+
+impl CertificateBody {
+    pub fn source_span(&self) -> Asn1Span {
+        self.source_span
+    }
+}
+
+impl CVCertPublicKey {
+    pub fn source_span(&self) -> Asn1Span {
+        self.source_span
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -102,7 +171,7 @@ pub struct Chat {
     pub relative_authorization: Vec<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// A CVC date encoded as digits `YYMMDD`.
 ///
 /// Each digit is stored as an octet `0..=9` (e.g. `250101` is `[2, 5, 0, 1, 0, 1]`).
@@ -146,9 +215,44 @@ impl CVCertificate {
     /// - date digit ranges and basic calendar constraints (month `1..=12`, day `1..=31`),
     /// - and rejects indefinite-length values in extension fields.
     pub fn parse(data: &[u8]) -> Asn1DecoderResult<Self> {
-        let decoder = Asn1Decoder::new(data);
-        let certificate = decoder.read(|scope| parse_cv_certificate_scope(scope))?;
+        let source = Asn1Source::new(data.to_vec());
+        let decoder = Asn1Decoder::new(source.as_bytes());
+        let certificate = decoder.read(|scope| {
+            let certificate = parse_cv_certificate_scope(scope, source.clone())?;
+            if scope.remaining_length() != 0 {
+                return Err(Asn1DecoderError::UnparsedBytesRemaining);
+            }
+            Ok(certificate)
+        })?;
         Ok(certificate)
+    }
+
+    pub fn source(&self) -> &Asn1Source {
+        &self.source
+    }
+
+    pub fn body_span(&self) -> Asn1Span {
+        self.body.source_span()
+    }
+
+    pub fn signature_span(&self) -> Asn1Span {
+        self.signature.source_span()
+    }
+
+    pub fn encoded_certificate_tlv(&self) -> &[u8] {
+        self.source.as_bytes()
+    }
+
+    pub fn encoded_body_tlv(&self) -> &[u8] {
+        self.source.encoded(self.body.source_span())
+    }
+
+    pub fn encoded_signature_tlv(&self) -> &[u8] {
+        self.source.encoded(self.signature.source_span())
+    }
+
+    pub fn encoded_public_key_tlv(&self) -> &[u8] {
+        self.source.encoded(self.body.public_key.source_span())
     }
 }
 
@@ -159,16 +263,22 @@ pub fn parse_cv_certificate(data: &[u8]) -> Asn1DecoderResult<CVCertificate> {
     CVCertificate::parse(data)
 }
 
-fn parse_cv_certificate_scope(scope: &mut ParserScope) -> Result<CVCertificate, Asn1DecoderError> {
-    scope.advance_with_tag(TAG_CV_CERTIFICATE.application_tag().constructed(), |scope| {
+fn parse_cv_certificate_scope(scope: &mut ParserScope, source: Asn1Source) -> Result<CVCertificate, Asn1DecoderError> {
+    let certificate = scope.advance_with_tag_spanned(TAG_CV_CERTIFICATE.application_tag().constructed(), |scope| {
         let body = parse_certificate_body(scope)?;
-        let signature = read_application_bytes(scope, TAG_SIGNATURE, 0, MAX_CERT_FIELD_LEN)?;
-        Ok(CVCertificate { body, signature })
+        let signature = read_application_bytes_spanned(scope, TAG_SIGNATURE, 0, MAX_CERT_FIELD_LEN)?;
+        Ok::<_, Asn1DecoderError>((body, signature))
+    })?;
+    let (body, signature) = certificate.value;
+    Ok(CVCertificate {
+        body: body.value,
+        signature: CVCertSignature { value: signature.value, source_span: signature.span },
+        source,
     })
 }
 
-fn parse_certificate_body(scope: &mut ParserScope) -> Result<CertificateBody, Asn1DecoderError> {
-    scope.advance_with_tag(TAG_CERTIFICATE_BODY.application_tag().constructed(), |scope| {
+fn parse_certificate_body(scope: &mut ParserScope) -> Result<Spanned<CertificateBody>, Asn1DecoderError> {
+    let body = scope.advance_with_tag_spanned(TAG_CERTIFICATE_BODY.application_tag().constructed(), |scope| {
         let profile_identifier = read_profile_identifier(scope)?;
         let certification_authority_reference =
             read_application_bytes(scope, TAG_CERTIFICATION_AUTHORITY_REFERENCE, 1, 16)?;
@@ -180,17 +290,19 @@ fn parse_certificate_body(scope: &mut ParserScope) -> Result<CertificateBody, As
         let certificate_extensions =
             if scope.remaining_length() > 0 { Some(parse_certificate_extensions(scope)?) } else { None };
 
-        Ok(CertificateBody {
+        Ok::<_, Asn1DecoderError>(CertificateBody {
             profile_identifier,
             certification_authority_reference,
-            public_key,
+            public_key: public_key.value,
             certificate_holder_reference,
             certificate_holder_authorization_template,
             certificate_effective_date,
             certificate_expiration_date,
             certificate_extensions,
+            source_span: Asn1Span::new(0, 0, 0, 0),
         })
-    })
+    })?;
+    Ok(Spanned { value: CertificateBody { source_span: body.span, ..body.value }, span: body.span })
 }
 
 fn read_profile_identifier(scope: &mut ParserScope) -> Result<u8, Asn1DecoderError> {
@@ -205,15 +317,20 @@ fn read_profile_identifier(scope: &mut ParserScope) -> Result<u8, Asn1DecoderErr
     Ok(value as u8)
 }
 
-fn parse_public_key(scope: &mut ParserScope) -> Result<CVCertPublicKey, Asn1DecoderError> {
-    scope.advance_with_tag(TAG_PUBLIC_KEY.application_tag().constructed(), |scope| {
-        let key_oid = scope.read_object_identifier()?;
-        let key_data = scope.read_bytes(scope.remaining_length())?;
-        if key_data.is_empty() {
-            return Err(Asn1DecoderError::custom("CVCertPublicKey data must not be empty"));
-        }
-        Ok(CVCertPublicKey { key_oid, key_data })
-    })
+fn parse_public_key(scope: &mut ParserScope) -> Result<Spanned<CVCertPublicKey>, Asn1DecoderError> {
+    scope
+        .advance_with_tag_spanned(TAG_PUBLIC_KEY.application_tag().constructed(), |scope| {
+            let key_oid = scope.read_object_identifier()?;
+            let key_data = scope.read_bytes(scope.remaining_length())?;
+            if key_data.is_empty() {
+                return Err(Asn1DecoderError::custom("CVCertPublicKey data must not be empty"));
+            }
+            Ok::<_, Asn1DecoderError>(CVCertPublicKey { key_oid, key_data, source_span: Asn1Span::new(0, 0, 0, 0) })
+        })
+        .map(|public_key| Spanned {
+            value: CVCertPublicKey { source_span: public_key.span, ..public_key.value },
+            span: public_key.span,
+        })
 }
 
 fn parse_chat(scope: &mut ParserScope) -> Result<Chat, Asn1DecoderError> {
@@ -269,6 +386,21 @@ fn read_application_bytes(
     max_len: usize,
 ) -> Result<Vec<u8>, Asn1DecoderError> {
     scope.advance_with_tag(tag_number.application_tag().primitive(), |scope| {
+        let len = scope.remaining_length();
+        if len < min_len || len > max_len {
+            return Err(Asn1DecoderError::custom(format!("Invalid length {len} for application tag {tag_number}")));
+        }
+        scope.read_bytes(len)
+    })
+}
+
+fn read_application_bytes_spanned(
+    scope: &mut ParserScope,
+    tag_number: u32,
+    min_len: usize,
+    max_len: usize,
+) -> Result<Spanned<Vec<u8>>, Asn1DecoderError> {
+    scope.advance_with_tag_spanned(tag_number.application_tag().primitive(), |scope| {
         let len = scope.remaining_length();
         if len < min_len || len > max_len {
             return Err(Asn1DecoderError::custom(format!("Invalid length {len} for application tag {tag_number}")));
@@ -622,6 +754,17 @@ mod tests {
         assert_eq!(cert.body.certificate_expiration_date, CertificateDate { year: 26, month: 12, day: 31 });
         assert!(cert.body.certificate_extensions.is_none());
         assert_eq!(cert.signature, vec![0xDE, 0xAD]);
+    }
+
+    #[test]
+    fn parsed_certificate_retains_original_tlv_spans() {
+        let data = build_test_certificate(false);
+        let cert = CVCertificate::parse(&data).expect("parse should succeed");
+
+        assert_eq!(cert.encoded_certificate_tlv(), data.as_ref());
+        assert!(cert.encoded_body_tlv().starts_with(&[0x7F, 0x4E]));
+        assert!(cert.encoded_public_key_tlv().starts_with(&[0x7F, 0x49]));
+        assert!(cert.encoded_signature_tlv().starts_with(&[0x5F, 0x37]));
     }
 
     #[test]

--- a/core-modules/asn1/src/cv_certificate.rs
+++ b/core-modules/asn1/src/cv_certificate.rs
@@ -754,6 +754,7 @@ mod tests {
         assert_eq!(cert.body.certificate_expiration_date, CertificateDate { year: 26, month: 12, day: 31 });
         assert!(cert.body.certificate_extensions.is_none());
         assert_eq!(cert.signature, vec![0xDE, 0xAD]);
+        assert_eq!(vec![0xDE, 0xAD], cert.signature);
     }
 
     #[test]

--- a/core-modules/asn1/src/decoder.rs
+++ b/core-modules/asn1/src/decoder.rs
@@ -21,6 +21,7 @@
 
 use crate::error::Asn1DecoderError;
 use crate::oid::ObjectIdentifier;
+use crate::source::{Asn1Span, Spanned};
 use crate::tag::{Asn1Class, Asn1Form, Asn1Id, UniversalTag};
 
 /// Length returned by [`ParserScope::read_length`].
@@ -117,6 +118,77 @@ impl<'a> ParserScope<'a> {
 
         self.end_offset = original_end;
         result
+    }
+
+    /// Advances the parser with the given tag and returns the parsed value together with
+    /// source offsets for the exact TLV that was consumed.
+    pub fn advance_with_tag_spanned<T, E>(
+        &mut self,
+        expected: Asn1Id,
+        mut block: impl FnMut(&mut ParserScope<'a>) -> Result<T, E>,
+    ) -> Result<Spanned<T>, E>
+    where
+        E: From<Asn1DecoderError>,
+    {
+        let tag_start = self.offset;
+        let tag = self.read_tag()?;
+        if tag != expected {
+            let describe = |id: &Asn1Id| {
+                let class: u8 = id.class.into();
+                let form: u8 = id.form.into();
+                format!("Asn1Id(class=0x{class:02X}, form=0x{form:02X}, number=0x{:X})", id.number)
+            };
+            return Err(
+                Asn1DecoderError::UnexpectedTag { expected: describe(&expected), actual: describe(&tag) }.into()
+            );
+        }
+        let length = self.read_length()?;
+        let value_start = self.offset;
+        let original_end = self.end_offset;
+
+        match length {
+            Asn1Length::Indefinite => {
+                self.end_offset = usize::MAX;
+            }
+            Asn1Length::Definite(len) => {
+                let new_end =
+                    self.offset.checked_add(len).ok_or_else(|| Asn1DecoderError::integer_overflow("scope end"))?;
+                if new_end > original_end {
+                    return Err(Asn1DecoderError::unexpected_end_of_data("length exceeds available data").into());
+                }
+                self.end_offset = new_end;
+            }
+        };
+
+        let value = match block(self) {
+            Ok(value) => value,
+            Err(err) => {
+                self.end_offset = original_end;
+                return Err(err);
+            }
+        };
+
+        let (value_end, end) = match length {
+            Asn1Length::Indefinite => {
+                let value_end = self.offset;
+                let end = self.read_bytes(2)?;
+                if end != [0x00, 0x00] {
+                    self.end_offset = original_end;
+                    return Err(Asn1DecoderError::MissingEndOfContentMarker.into());
+                }
+                (value_end, self.offset)
+            }
+            Asn1Length::Definite(_) => {
+                if self.end_offset != self.offset {
+                    self.end_offset = original_end;
+                    return Err(Asn1DecoderError::UnparsedBytesRemaining.into());
+                }
+                (self.offset, self.offset)
+            }
+        };
+
+        self.end_offset = original_end;
+        Ok(Spanned::new(value, Asn1Span::new(tag_start, value_start, value_end, end)))
     }
 
     /// Read one byte.
@@ -337,6 +409,7 @@ impl<'a> Asn1Decoder<'a> {
 mod tests {
     use super::*;
     use crate::date_time::{Asn1Offset, Asn1Time};
+    use crate::source::Asn1Source;
     use crate::tag::UniversalTag;
 
     fn hex_bytes(s: &str) -> Vec<u8> {
@@ -366,6 +439,116 @@ mod tests {
             })
             .unwrap();
         assert_eq!(result, vec!["foo".to_string(), "bar".to_string()]);
+    }
+
+    #[test]
+    fn advance_with_tag_spanned_records_nested_tlv_offsets() {
+        let data = hex_bytes("30 0A 04 03 66 6F 6F 04 03 62 61 72");
+        let source = Asn1Source::new(data.clone());
+        let parser = Asn1Decoder::new(&data);
+
+        let result = parser
+            .read(|s| {
+                s.advance_with_tag_spanned(UniversalTag::Sequence.constructed(), |s| {
+                    let first = s.advance_with_tag_spanned(
+                        UniversalTag::OctetString.primitive(),
+                        |s| -> Result<_, Asn1DecoderError> { s.read_bytes(3) },
+                    )?;
+                    let second = s.advance_with_tag_spanned(
+                        UniversalTag::OctetString.primitive(),
+                        |s| -> Result<_, Asn1DecoderError> { s.read_bytes(3) },
+                    )?;
+                    Ok::<_, Asn1DecoderError>((first, second))
+                })
+            })
+            .unwrap();
+
+        assert_eq!(result.span, Asn1Span::new(0, 2, 12, 12));
+        assert_eq!(source.encoded(result.span), data.as_slice());
+        assert_eq!(source.value(result.span), &data[2..12]);
+
+        let (first, second) = result.value;
+        assert_eq!(first.span, Asn1Span::new(2, 4, 7, 7));
+        assert_eq!(first.value, b"foo");
+        assert_eq!(source.encoded(first.span), &data[2..7]);
+        assert_eq!(source.value(first.span), b"foo");
+
+        assert_eq!(second.span, Asn1Span::new(7, 9, 12, 12));
+        assert_eq!(second.value, b"bar");
+        assert_eq!(source.encoded(second.span), &data[7..12]);
+        assert_eq!(source.value(second.span), b"bar");
+    }
+
+    #[test]
+    fn advance_with_tag_spanned_records_long_form_length_offsets() {
+        let mut data = vec![0x04, 0x81, 0x80];
+        data.extend(0..=127);
+        let source = Asn1Source::new(data.clone());
+        let parser = Asn1Decoder::new(&data);
+
+        let result = parser
+            .read(|s| {
+                s.advance_with_tag_spanned(UniversalTag::OctetString.primitive(), |s| -> Result<_, Asn1DecoderError> {
+                    s.read_bytes(128)
+                })
+            })
+            .unwrap();
+
+        assert_eq!(result.span, Asn1Span::new(0, 3, 131, 131));
+        assert_eq!(source.encoded(result.span), data.as_slice());
+        assert_eq!(source.value(result.span), &data[3..]);
+        assert_eq!(result.value, data[3..]);
+    }
+
+    #[test]
+    fn advance_with_tag_spanned_records_indefinite_length_offsets() {
+        let data = hex_bytes("30 80 04 01 AA 00 00");
+        let source = Asn1Source::new(data.clone());
+        let parser = Asn1Decoder::new(&data);
+
+        let result = parser
+            .read(|s| {
+                s.advance_with_tag_spanned(UniversalTag::Sequence.constructed(), |s| {
+                    s.advance_with_tag_spanned(
+                        UniversalTag::OctetString.primitive(),
+                        |s| -> Result<_, Asn1DecoderError> { s.read_bytes(1) },
+                    )
+                })
+            })
+            .unwrap();
+
+        assert_eq!(result.span, Asn1Span::new(0, 2, 5, 7));
+        assert_eq!(source.encoded(result.span), data.as_slice());
+        assert_eq!(source.value(result.span), &data[2..5]);
+        assert_eq!(result.value.span, Asn1Span::new(2, 4, 5, 5));
+        assert_eq!(result.value.value, vec![0xAA]);
+    }
+
+    #[test]
+    fn advance_with_tag_spanned_restores_scope_after_block_error() {
+        let data = hex_bytes("30 06 04 01 AA 04 01 BB");
+        let parser = Asn1Decoder::new(&data);
+
+        parser
+            .read(|s| {
+                s.advance_with_tag(UniversalTag::Sequence.constructed(), |s| -> Result<(), Asn1DecoderError> {
+                    let err = s
+                        .advance_with_tag_spanned(
+                            UniversalTag::OctetString.primitive(),
+                            |s| -> Result<(), Asn1DecoderError> {
+                                let _ = s.read_bytes(1)?;
+                                Err(Asn1DecoderError::custom("forced parse error"))
+                            },
+                        )
+                        .unwrap_err();
+                    assert!(matches!(err, Asn1DecoderError::Custom { .. }));
+
+                    let remaining = s.read_bytes(3)?;
+                    assert_eq!(remaining, vec![0x04, 0x01, 0xBB]);
+                    Ok(())
+                })
+            })
+            .unwrap();
     }
 
     #[test]

--- a/core-modules/asn1/src/encoder.rs
+++ b/core-modules/asn1/src/encoder.rs
@@ -159,6 +159,23 @@ impl WriterScope {
         })
     }
 
+    /// Write a non-negative ASN.1 integer from big-endian magnitude bytes.
+    ///
+    /// The value is encoded in the minimal positive two's-complement form required by DER:
+    /// redundant leading zeroes are removed, and a single leading zero is added when the most
+    /// significant value byte would otherwise mark the INTEGER as negative.
+    pub fn write_asn1_unsigned_integer_bytes(&mut self, value: &[u8]) -> Result<(), Asn1EncoderError> {
+        self.write_tagged_object(UniversalTag::Integer.primitive(), |s| {
+            let first_significant = value.iter().position(|byte| *byte != 0);
+            let value = first_significant.map_or(&[0][..], |idx| &value[idx..]);
+            if value.first().map(|byte| byte & 0x80 != 0).unwrap_or(false) {
+                s.write_byte(0);
+            }
+            s.write_bytes(value);
+            Ok(())
+        })
+    }
+
     /// Write an ASN.1 boolean.
     pub fn write_asn1_boolean(&mut self, value: bool) -> Result<(), Asn1EncoderError> {
         self.write_tagged_object(UniversalTag::Boolean.primitive(), |s| {
@@ -358,6 +375,25 @@ mod tests {
     fn write_int_zero() {
         let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_int(0)).unwrap();
         assert_eq!(hex(&result), "02 01 00");
+    }
+
+    #[test]
+    fn write_unsigned_integer_bytes_zero() {
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_unsigned_integer_bytes(&[])).unwrap();
+        assert_eq!(hex(&result), "02 01 00");
+
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_unsigned_integer_bytes(&[0x00, 0x00])).unwrap();
+        assert_eq!(hex(&result), "02 01 00");
+    }
+
+    #[test]
+    fn write_unsigned_integer_bytes_der_canonicalizes_positive_values() {
+        let result =
+            Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_unsigned_integer_bytes(&[0x00, 0x00, 0x7F])).unwrap();
+        assert_eq!(hex(&result), "02 01 7F");
+
+        let result = Asn1Encoder::write_nonzeroizing(|w| w.write_asn1_unsigned_integer_bytes(&[0x00, 0x80])).unwrap();
+        assert_eq!(hex(&result), "02 02 00 80");
     }
 
     #[test]

--- a/core-modules/asn1/src/ffi/mod.rs
+++ b/core-modules/asn1/src/ffi/mod.rs
@@ -121,24 +121,45 @@ impl From<Asn1Tag> for CoreAsn1Id {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct CvCertificate {
-    body: CvCertificateBody,
-    signature: Vec<u8>,
+    inner: crate::cv_certificate::CVCertificate,
 }
 
 impl From<crate::cv_certificate::CVCertificate> for CvCertificate {
     fn from(value: crate::cv_certificate::CVCertificate) -> Self {
-        Self { body: value.body.into(), signature: value.signature }
+        Self { inner: value }
+    }
+}
+
+impl CvCertificate {
+    pub fn as_core(&self) -> &crate::cv_certificate::CVCertificate {
+        &self.inner
     }
 }
 
 #[uniffi::export]
 impl CvCertificate {
     pub fn body(&self) -> Arc<CvCertificateBody> {
-        Arc::new(self.body.clone())
+        Arc::new(self.inner.body.clone().into())
     }
 
     pub fn signature(&self) -> Vec<u8> {
-        self.signature.clone()
+        self.inner.signature.to_vec()
+    }
+
+    pub fn encoded_certificate_tlv(&self) -> Vec<u8> {
+        self.inner.encoded_certificate_tlv().to_vec()
+    }
+
+    pub fn encoded_body_tlv(&self) -> Vec<u8> {
+        self.inner.encoded_body_tlv().to_vec()
+    }
+
+    pub fn encoded_public_key_tlv(&self) -> Vec<u8> {
+        self.inner.encoded_public_key_tlv().to_vec()
+    }
+
+    pub fn encoded_signature_tlv(&self) -> Vec<u8> {
+        self.inner.encoded_signature_tlv().to_vec()
     }
 }
 

--- a/core-modules/asn1/src/ffi/mod.rs
+++ b/core-modules/asn1/src/ffi/mod.rs
@@ -486,6 +486,12 @@ impl From<Asn1TagForm> for CoreAsn1Form {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encoder::Asn1Encoder;
+    use crate::error::Asn1EncoderError;
+    use crate::oid::ObjectIdentifier;
+    use crate::tag::TagNumberExt;
+
+    type EncResult = Result<(), Asn1EncoderError>;
 
     fn hex_to_bytes(hex_str: &str) -> Vec<u8> {
         let mut out = Vec::new();
@@ -497,6 +503,75 @@ mod tests {
             out.push(byte);
         }
         out
+    }
+
+    fn build_cv_certificate_with_extensions() -> Vec<u8> {
+        Asn1Encoder::write_nonzeroizing::<Asn1EncoderError>(|w| {
+            w.write_tagged_object(33u32.application_tag().constructed(), |cert| -> EncResult {
+                cert.write_tagged_object(78u32.application_tag().constructed(), |body| -> EncResult {
+                    body.write_tagged_object(41u32.application_tag(), |field| -> EncResult {
+                        field.write_bytes(&[0x70]);
+                        Ok(())
+                    })?;
+                    body.write_tagged_object(2u32.application_tag(), |field| -> EncResult {
+                        field.write_bytes(b"CAR");
+                        Ok(())
+                    })?;
+                    body.write_tagged_object(73u32.application_tag().constructed(), |field| -> EncResult {
+                        field.write_object_identifier(&ObjectIdentifier::parse("1.2.3.4").unwrap())?;
+                        field.write_bytes(&[0x86, 0x01, 0x04]);
+                        Ok(())
+                    })?;
+                    body.write_tagged_object(32u32.application_tag(), |field| -> EncResult {
+                        field.write_bytes(b"CHR");
+                        Ok(())
+                    })?;
+                    body.write_tagged_object(76u32.application_tag().constructed(), |chat| -> EncResult {
+                        chat.write_object_identifier(&ObjectIdentifier::parse("1.2.3").unwrap())?;
+                        chat.write_tagged_object(19u32.application_tag(), |field| -> EncResult {
+                            field.write_bytes(&[0xAA]);
+                            Ok(())
+                        })?;
+                        Ok(())
+                    })?;
+                    body.write_tagged_object(37u32.application_tag(), |field| -> EncResult {
+                        field.write_bytes(&[2, 5, 0, 1, 0, 1]);
+                        Ok(())
+                    })?;
+                    body.write_tagged_object(36u32.application_tag(), |field| -> EncResult {
+                        field.write_bytes(&[2, 6, 0, 1, 0, 1]);
+                        Ok(())
+                    })?;
+                    body.write_tagged_object(5u32.application_tag().constructed(), |extensions| -> EncResult {
+                        extensions.write_tagged_object(
+                            19u32.application_tag().constructed(),
+                            |template| -> EncResult {
+                                template.write_object_identifier(&ObjectIdentifier::parse("1.2.3.5").unwrap())?;
+                                template.write_tagged_object(0u8.context_tag(), |field| -> EncResult {
+                                    field.write_bytes(&[0x10]);
+                                    Ok(())
+                                })?;
+                                template.write_tagged_object(1u8.context_tag(), |field| -> EncResult {
+                                    field.write_bytes(&[0x20, 0x30]);
+                                    Ok(())
+                                })?;
+                                Ok(())
+                            },
+                        )?;
+                        Ok(())
+                    })?;
+                    Ok(())
+                })?;
+                cert.write_tagged_object(55u32.application_tag(), |signature| -> EncResult {
+                    signature.write_bytes(&[0xDE, 0xAD]);
+                    Ok(())
+                })?;
+                Ok(())
+            })
+        })
+        .expect("test certificate should encode")
+        .as_ref()
+        .to_vec()
     }
 
     #[test]
@@ -524,6 +599,31 @@ mod tests {
         assert_eq!(expiration_date.year(), 29);
         assert_eq!(expiration_date.month(), 4);
         assert_eq!(expiration_date.day(), 1);
+        assert!(body.certificate_extensions().is_none());
+        assert_eq!(vec![0x9D, 0x24], &cert.signature()[..2]);
+        assert!(cert.encoded_certificate_tlv().starts_with(&[0x7F, 0x21]));
+        assert!(cert.encoded_body_tlv().starts_with(&[0x7F, 0x4E]));
+        assert!(cert.encoded_public_key_tlv().starts_with(&[0x7F, 0x49]));
+        assert!(cert.encoded_signature_tlv().starts_with(&[0x5F, 0x37]));
+    }
+
+    #[test]
+    fn parse_cv_certificate_maps_extensions() {
+        let cert = parse_cv_certificate(build_cv_certificate_with_extensions()).expect("parse should succeed");
+        let body = cert.body();
+        let extensions = body.certificate_extensions().expect("extensions should be present");
+
+        let templates = extensions.templates();
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].extension_id_oid(), "1.2.3.5");
+
+        let fields = templates[0].extension_data();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].tag().class_(), Asn1TagClass::ContextSpecific);
+        assert_eq!(fields[0].tag().number(), 0);
+        assert_eq!(fields[0].value(), vec![0x10]);
+        assert_eq!(fields[1].tag().number(), 1);
+        assert_eq!(fields[1].value(), vec![0x20, 0x30]);
     }
 
     #[test]

--- a/core-modules/asn1/src/lib.rs
+++ b/core-modules/asn1/src/lib.rs
@@ -28,6 +28,7 @@ pub mod extraction;
 pub mod ffi;
 pub mod maybe_zeroizing_vec;
 pub mod oid;
+pub mod source;
 pub mod tag;
 
 #[cfg(feature = "uniffi")]

--- a/core-modules/asn1/src/source.rs
+++ b/core-modules/asn1/src/source.rs
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright 2026 gematik GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *******
+//
+// For additional notes and disclaimer from gematik and in case of changes by gematik,
+// find details in the "Readme" file.
+
+use std::sync::Arc;
+
+/// Byte offsets for one parsed ASN.1 TLV inside its original source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Asn1Span {
+    tag_start: usize,
+    value_start: usize,
+    value_end: usize,
+    end: usize,
+}
+
+impl Asn1Span {
+    pub fn new(tag_start: usize, value_start: usize, value_end: usize, end: usize) -> Self {
+        Self { tag_start, value_start, value_end, end }
+    }
+
+    pub fn tag_start(&self) -> usize {
+        self.tag_start
+    }
+
+    pub fn value_start(&self) -> usize {
+        self.value_start
+    }
+
+    pub fn value_end(&self) -> usize {
+        self.value_end
+    }
+
+    pub fn end(&self) -> usize {
+        self.end
+    }
+}
+
+/// A parsed value with the ASN.1 span it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Spanned<T> {
+    pub value: T,
+    pub span: Asn1Span,
+}
+
+impl<T> Spanned<T> {
+    pub fn new(value: T, span: Asn1Span) -> Self {
+        Self { value, span }
+    }
+
+    pub fn into_value(self) -> T {
+        self.value
+    }
+}
+
+/// Shared original ASN.1 input bytes used to recover exact encoded TLVs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Asn1Source {
+    bytes: Arc<[u8]>,
+}
+
+impl Asn1Source {
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Self {
+        Self { bytes: Arc::<[u8]>::from(bytes.into()) }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn encoded(&self, span: Asn1Span) -> &[u8] {
+        &self.bytes[span.tag_start..span.end]
+    }
+
+    pub fn value(&self, span: Asn1Span) -> &[u8] {
+        &self.bytes[span.value_start..span.value_end]
+    }
+}

--- a/core-modules/crypto/Cargo.toml
+++ b/core-modules/crypto/Cargo.toml
@@ -32,12 +32,14 @@ name = "openhealth_crypto"
 [features]
 default = ["uniffi"]
 ci = ["uniffi"]
+uniffi = ["dep:uniffi", "openhealth_asn1/uniffi"]
 
 [dependencies]
 openhealth_asn1 = { package = "asn1", path = "../asn1" }
 crypto-openssl-sys = { path = "../crypto-openssl-sys" }
 regex = "1.12.2"
 base64 = "0.22.1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 num-bigint = "0.4"
 num-traits = "0.2.19"
 zeroize = { version = "1.8.1", features = ["zeroize_derive"] }

--- a/core-modules/crypto/src/cvc.rs
+++ b/core-modules/crypto/src/cvc.rs
@@ -1,0 +1,370 @@
+// SPDX-FileCopyrightText: Copyright 2026 gematik GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *******
+//
+// For additional notes and disclaimer from gematik and in case of changes by gematik,
+// find details in the "Readme" file.
+
+use std::time::SystemTime;
+
+use chrono::{DateTime, Datelike, Utc};
+use openhealth_asn1::cv_certificate::{CVCertPublicKey, CVCertificate, CertificateDate};
+use openhealth_asn1::decoder::Asn1Decoder;
+use openhealth_asn1::encoder::Asn1Encoder;
+use openhealth_asn1::extraction::extract_context_values;
+use openhealth_asn1::tag::{TagNumberExt, UniversalTag};
+
+use crate::error::{CryptoError, CryptoResult};
+use crate::ossl;
+
+const CVC_PROFILE_G2: u8 = 0x70;
+const OID_ECDSA_SHA256: &str = "1.2.840.10045.4.3.2";
+const OID_ECDSA_SHA384: &str = "1.2.840.10045.4.3.3";
+const OID_ECDSA_SHA512: &str = "1.2.840.10045.4.3.4";
+
+#[derive(Debug, Clone)]
+pub struct CvcTrustAnchor {
+    reference: Vec<u8>,
+    public_key: CvcPublicKey,
+}
+
+impl CvcTrustAnchor {
+    pub fn from_certificate(certificate: &CVCertificate) -> CryptoResult<Self> {
+        let public_key = CvcPublicKey::from_cert_public_key(&certificate.body.public_key)?;
+        Ok(Self { reference: certificate.body.certificate_holder_reference.clone(), public_key })
+    }
+
+    pub fn from_public_key_tlv(reference: Vec<u8>, public_key_tlv: &[u8]) -> CryptoResult<Self> {
+        if reference.is_empty() {
+            return Err(invalid_chain("trust anchor reference must not be empty"));
+        }
+        let public_key = parse_public_key_tlv(public_key_tlv)?;
+        Ok(Self { reference, public_key })
+    }
+
+    pub fn reference(&self) -> &[u8] {
+        &self.reference
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CvcChainValidationResult {
+    validated_certificates: usize,
+    end_entity_chr: Vec<u8>,
+}
+
+impl CvcChainValidationResult {
+    pub fn validated_certificates(&self) -> usize {
+        self.validated_certificates
+    }
+
+    pub fn end_entity_chr(&self) -> &[u8] {
+        &self.end_entity_chr
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CvcPublicKey {
+    point: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct CvcDate {
+    year: i32,
+    month: u32,
+    day: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SignatureProfile {
+    curve_name: &'static str,
+    digest_name: &'static str,
+    coordinate_len: usize,
+}
+
+pub fn validate_cvc_chain(
+    chain: &[CVCertificate],
+    trust_anchors: &[CvcTrustAnchor],
+    validation_time: SystemTime,
+) -> CryptoResult<CvcChainValidationResult> {
+    if chain.is_empty() {
+        return Err(invalid_chain("chain must not be empty"));
+    }
+    if trust_anchors.is_empty() {
+        return Err(invalid_chain("at least one trust anchor is required"));
+    }
+
+    let validation_date = system_time_to_utc_date(validation_time);
+    let first = &chain[0];
+    validate_profile_and_date(first, validation_date)?;
+    let trust_anchor = trust_anchors
+        .iter()
+        .find(|anchor| anchor.reference == first.body.certification_authority_reference)
+        .ok_or_else(|| invalid_chain("no trust anchor matching first certificate CAR"))?;
+    verify_certificate_signature(first, &trust_anchor.public_key, "trust anchor")?;
+
+    let mut issuer_public_key = CvcPublicKey::from_cert_public_key(&first.body.public_key)?;
+    let mut issuer = first;
+    for child in chain.iter().skip(1) {
+        validate_profile_and_date(child, validation_date)?;
+        if child.body.certification_authority_reference != issuer.body.certificate_holder_reference {
+            return Err(invalid_chain("certificate CAR does not match issuer CHR"));
+        }
+        validate_chat_is_subset(issuer, child)?;
+        verify_certificate_signature(child, &issuer_public_key, "issuer certificate")?;
+        issuer_public_key = CvcPublicKey::from_cert_public_key(&child.body.public_key)?;
+        issuer = child;
+    }
+
+    let end_entity_chr = chain.last().expect("chain is non-empty").body.certificate_holder_reference.clone();
+    Ok(CvcChainValidationResult { validated_certificates: chain.len(), end_entity_chr })
+}
+
+fn validate_profile_and_date(certificate: &CVCertificate, validation_date: CvcDate) -> CryptoResult<()> {
+    if certificate.body.profile_identifier != CVC_PROFILE_G2 {
+        return Err(invalid_chain(format!(
+            "unsupported CVC profile identifier 0x{:02X}",
+            certificate.body.profile_identifier
+        )));
+    }
+    let not_before = CvcDate::from_certificate_date(certificate.body.certificate_effective_date);
+    let not_after = CvcDate::from_certificate_date(certificate.body.certificate_expiration_date);
+    if validation_date < not_before {
+        return Err(invalid_chain("certificate is not yet effective"));
+    }
+    if validation_date > not_after {
+        return Err(invalid_chain("certificate is expired"));
+    }
+    Ok(())
+}
+
+fn validate_chat_is_subset(issuer: &CVCertificate, child: &CVCertificate) -> CryptoResult<()> {
+    let issuer_chat = &issuer.body.certificate_holder_authorization_template;
+    let child_chat = &child.body.certificate_holder_authorization_template;
+    if issuer_chat.terminal_type != child_chat.terminal_type {
+        return Err(invalid_chain("child CHAT terminal type differs from issuer"));
+    }
+    if issuer_chat.relative_authorization.len() != child_chat.relative_authorization.len() {
+        return Err(invalid_chain("child CHAT authorization length differs from issuer"));
+    }
+    if child_chat
+        .relative_authorization
+        .iter()
+        .zip(issuer_chat.relative_authorization.iter())
+        .any(|(child, issuer)| child & !issuer != 0)
+    {
+        return Err(invalid_chain("child CHAT authorization is not a subset of issuer authorization"));
+    }
+    Ok(())
+}
+
+fn verify_certificate_signature(
+    certificate: &CVCertificate,
+    issuer_public_key: &CvcPublicKey,
+    issuer_label: &str,
+) -> CryptoResult<()> {
+    let profile =
+        SignatureProfile::from_public_key_and_algorithm(issuer_public_key, &certificate.body.public_key.key_oid)?;
+    let signature = der_encode_plain_ecdsa_signature(&certificate.signature, profile.coordinate_len)?;
+    let public_key = ossl::cvc::EcPublicKey::from_uncompressed(profile.curve_name, &issuer_public_key.point)?;
+    let valid = ossl::cvc::verify_ecdsa(&public_key, profile.digest_name, certificate.encoded_body_tlv(), &signature)?;
+    if valid {
+        Ok(())
+    } else {
+        Err(CryptoError::InvalidCvcSignature { context: format!("signature check failed with {issuer_label}") })
+    }
+}
+
+fn parse_public_key_tlv(data: &[u8]) -> CryptoResult<CvcPublicKey> {
+    let point = Asn1Decoder::new(data).read(|scope| {
+        scope.advance_with_tag(73u8.application_tag().constructed(), |scope| {
+            let _oid = scope.read_object_identifier()?;
+            let key_data = scope.read_bytes(scope.remaining_length())?;
+            let values = extract_context_values(&key_data, 6)?;
+            values.last().cloned().ok_or_else(|| {
+                openhealth_asn1::error::Asn1DecoderError::custom("CVC public key does not contain context tag 6")
+            })
+        })
+    })?;
+    SignatureProfile::from_point_len(point.len())?;
+    Ok(CvcPublicKey { point })
+}
+
+impl CvcPublicKey {
+    fn from_cert_public_key(public_key: &CVCertPublicKey) -> CryptoResult<Self> {
+        let values = extract_context_values(&public_key.key_data, 6)?;
+        let point =
+            values.last().cloned().ok_or_else(|| invalid_chain("CVC public key does not contain context tag 6"))?;
+        SignatureProfile::from_point_len(point.len())?;
+        Ok(Self { point })
+    }
+}
+
+impl SignatureProfile {
+    fn from_point_len(point_len: usize) -> CryptoResult<Self> {
+        match point_len {
+            65 => Ok(Self { curve_name: "brainpoolP256r1", digest_name: "SHA256", coordinate_len: 32 }),
+            97 => Ok(Self { curve_name: "brainpoolP384r1", digest_name: "SHA384", coordinate_len: 48 }),
+            129 => Ok(Self { curve_name: "brainpoolP512r1", digest_name: "SHA512", coordinate_len: 64 }),
+            _ => Err(invalid_chain(format!("unsupported CVC public key point length {point_len}"))),
+        }
+    }
+
+    fn from_public_key_and_algorithm(
+        public_key: &CvcPublicKey,
+        algorithm_oid: &openhealth_asn1::oid::ObjectIdentifier,
+    ) -> CryptoResult<Self> {
+        let profile = Self::from_point_len(public_key.point.len())?;
+        let expected_oid = match profile.coordinate_len {
+            32 => OID_ECDSA_SHA256,
+            48 => OID_ECDSA_SHA384,
+            64 => OID_ECDSA_SHA512,
+            _ => unreachable!(),
+        };
+        let algorithm_oid = algorithm_oid.to_string();
+        if algorithm_oid != expected_oid {
+            return Err(invalid_chain(format!(
+                "unsupported or mismatched CVC signature algorithm OID {algorithm_oid}"
+            )));
+        }
+        Ok(profile)
+    }
+}
+
+impl CvcDate {
+    fn from_certificate_date(date: CertificateDate) -> Self {
+        Self { year: 2000 + i32::from(date.year), month: u32::from(date.month), day: u32::from(date.day) }
+    }
+}
+
+fn system_time_to_utc_date(time: SystemTime) -> CvcDate {
+    let datetime: DateTime<Utc> = time.into();
+    CvcDate { year: datetime.year(), month: datetime.month(), day: datetime.day() }
+}
+
+fn der_encode_plain_ecdsa_signature(signature: &[u8], coordinate_len: usize) -> CryptoResult<Vec<u8>> {
+    let expected_len = coordinate_len * 2;
+    if signature.len() != expected_len {
+        return Err(invalid_chain(format!(
+            "invalid CVC ECDSA signature length: expected {expected_len}, got {}",
+            signature.len()
+        )));
+    }
+    let encoded = Asn1Encoder::write_nonzeroizing::<CryptoError>(|scope| {
+        scope.write_tagged_object(UniversalTag::Sequence.constructed(), |sequence| -> CryptoResult<()> {
+            sequence.write_asn1_unsigned_integer_bytes(&signature[..coordinate_len])?;
+            sequence.write_asn1_unsigned_integer_bytes(&signature[coordinate_len..])?;
+            Ok(())
+        })
+    })?;
+    Ok(encoded.as_ref().to_vec())
+}
+
+fn invalid_chain(context: impl Into<String>) -> CryptoError {
+    CryptoError::InvalidCvcChain { context: context.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn fixture_path(parts: &[&str]) -> PathBuf {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop();
+        path.pop();
+        path.push("test-vectors");
+        path.push("cvc-chain");
+        path.push("pki_cvc_g2_input");
+        for part in parts {
+            path.push(part);
+        }
+        path
+    }
+
+    fn load_cvc(name: &str) -> CVCertificate {
+        let path = fixture_path(&["Atos_CVC-Root-CA", name]);
+        let bytes = fs::read(path).expect("fixture should be readable");
+        CVCertificate::parse(&bytes).expect("fixture should parse")
+    }
+
+    fn load_anchor(reference: &[u8], name: &str) -> CvcTrustAnchor {
+        let path = fixture_path(&["trust-anchor", name]);
+        let bytes = fs::read(path).expect("fixture should be readable");
+        CvcTrustAnchor::from_public_key_tlv(reference.to_vec(), &bytes).expect("anchor should parse")
+    }
+
+    fn validation_time(year: i32, month: u32, day: u32) -> SystemTime {
+        Utc.with_ymd_and_hms(year, month, day, 12, 0, 0).single().unwrap().into()
+    }
+
+    #[test]
+    fn validates_self_signed_root_against_public_key_anchor() {
+        let cert = load_cvc("DEGXX820214.cvc");
+        let anchor = load_anchor(&hex::decode("4445475858820214").unwrap(), "4445475858820214_ELC-PublicKey.der");
+
+        let result = validate_cvc_chain(&[cert], &[anchor], validation_time(2020, 1, 1)).unwrap();
+
+        assert_eq!(result.validated_certificates(), 1);
+        assert_eq!(hex::encode(result.end_entity_chr()), "4445475858820214");
+    }
+
+    #[test]
+    fn validates_cross_signed_chain_against_public_key_anchor() {
+        let issuer = load_cvc("DEGXX830214_cross.cvc");
+        let child = load_cvc("DEGXX840216_830214_cross.cvc");
+        let anchor = load_anchor(&hex::decode("4445475858820214").unwrap(), "4445475858820214_ELC-PublicKey.der");
+
+        let result = validate_cvc_chain(&[issuer, child], &[anchor], validation_time(2017, 1, 1)).unwrap();
+
+        assert_eq!(result.validated_certificates(), 2);
+        assert_eq!(hex::encode(result.end_entity_chr()), "4445475858840216");
+    }
+
+    #[test]
+    fn rejects_tampered_signature() {
+        let mut cert = load_cvc("DEGXX820214.cvc");
+        let anchor = load_anchor(&hex::decode("4445475858820214").unwrap(), "4445475858820214_ELC-PublicKey.der");
+        cert.signature[0] ^= 0x01;
+
+        let err = validate_cvc_chain(&[cert], &[anchor], validation_time(2020, 1, 1)).unwrap_err();
+
+        assert!(matches!(err, CryptoError::InvalidCvcSignature { .. }));
+    }
+
+    #[test]
+    fn rejects_expired_certificate() {
+        let cert = load_cvc("DEGXX820214.cvc");
+        let anchor = load_anchor(&hex::decode("4445475858820214").unwrap(), "4445475858820214_ELC-PublicKey.der");
+
+        let err = validate_cvc_chain(&[cert], &[anchor], validation_time(2025, 1, 1)).unwrap_err();
+
+        assert!(matches!(err, CryptoError::InvalidCvcChain { .. }));
+    }
+
+    #[test]
+    fn rejects_wrong_trust_anchor_reference() {
+        let cert = load_cvc("DEGXX820214.cvc");
+        let anchor = load_anchor(&hex::decode("4445475858830214").unwrap(), "4445475858820214_ELC-PublicKey.der");
+
+        let err = validate_cvc_chain(&[cert], &[anchor], validation_time(2020, 1, 1)).unwrap_err();
+
+        assert!(matches!(err, CryptoError::InvalidCvcChain { .. }));
+    }
+}

--- a/core-modules/crypto/src/error.rs
+++ b/core-modules/crypto/src/error.rs
@@ -45,6 +45,12 @@ pub enum CryptoError {
     /// An elliptic curve point was invalid or malformed.
     #[error("invalid ec point: {0}")]
     InvalidEcPoint(String),
+    /// CV certificate validation failed.
+    #[error("invalid CVC chain: {context}")]
+    InvalidCvcChain { context: String },
+    /// A CV certificate signature was cryptographically invalid.
+    #[error("invalid CVC signature: {context}")]
+    InvalidCvcSignature { context: String },
     /// Underlying native cryptographic failure with original message.
     #[error("native error: {0}")]
     Native(String),

--- a/core-modules/crypto/src/ffi.rs
+++ b/core-modules/crypto/src/ffi.rs
@@ -19,13 +19,16 @@
 // For additional notes and disclaimer from gematik and in case of changes by gematik,
 // find details in the "Readme" file.
 
+use crate::cvc as core_cvc;
 use crate::ec::ec_key::{EcCurve, EcKeyPairSpec, EcPrivateKey, EcPublicKey};
 use crate::error::CryptoError as CoreCryptoError;
 use crate::exchange::ecdh::Ecdh;
 use crate::exchange::elc::generate_elc_ephemeral_public_key_from_cvc;
 use crate::key::SecretKey;
 use crate::mac::{CmacAlgorithm, MacSpec};
+use openhealth_asn1::ffi::CvCertificate;
 use std::sync::Arc;
+use std::time::SystemTime;
 use thiserror::Error;
 
 /// UniFFI-friendly error type for exported crypto helpers.
@@ -45,6 +48,8 @@ impl From<CoreCryptoError> for CryptoError {
         match err {
             CoreCryptoError::Asn1Decoding(inner) => Self::Asn1Decode { reason: inner.to_string() },
             CoreCryptoError::InvalidEcPoint(reason) => Self::InvalidArgument { reason },
+            CoreCryptoError::InvalidCvcChain { context } => Self::InvalidArgument { reason: context },
+            CoreCryptoError::InvalidCvcSignature { context } => Self::Crypto { reason: context },
             CoreCryptoError::InvalidKeyMaterial { context } => Self::InvalidArgument { reason: context.to_owned() },
             CoreCryptoError::InvalidKeyLength { expected, actual } => Self::InvalidArgument {
                 reason: format!("invalid key length: expected one of {expected:?}, got {actual}"),
@@ -68,6 +73,47 @@ pub struct BrainpoolP256r1KeyPair {
     public_key: Vec<u8>,
 }
 
+#[derive(uniffi::Object)]
+pub struct CvcTrustAnchor {
+    inner: core_cvc::CvcTrustAnchor,
+}
+
+#[uniffi::export]
+impl CvcTrustAnchor {
+    #[uniffi::constructor]
+    pub fn from_certificate(certificate: Arc<CvCertificate>) -> Result<Arc<Self>, CryptoError> {
+        let inner = core_cvc::CvcTrustAnchor::from_certificate(certificate.as_core()).map_err(CryptoError::from)?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    #[uniffi::constructor]
+    pub fn from_public_key_tlv(reference: Vec<u8>, public_key_tlv: Vec<u8>) -> Result<Arc<Self>, CryptoError> {
+        let inner =
+            core_cvc::CvcTrustAnchor::from_public_key_tlv(reference, &public_key_tlv).map_err(CryptoError::from)?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    pub fn reference(&self) -> Vec<u8> {
+        self.inner.reference().to_vec()
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct CvcChainValidationResult {
+    inner: core_cvc::CvcChainValidationResult,
+}
+
+#[uniffi::export]
+impl CvcChainValidationResult {
+    pub fn validated_certificates(&self) -> u64 {
+        self.inner.validated_certificates() as u64
+    }
+
+    pub fn end_entity_chr(&self) -> Vec<u8> {
+        self.inner.end_entity_chr().to_vec()
+    }
+}
+
 #[uniffi::export]
 impl BrainpoolP256r1KeyPair {
     pub fn private_key(&self) -> Vec<u8> {
@@ -83,6 +129,18 @@ impl BrainpoolP256r1KeyPair {
 #[uniffi::export]
 pub fn generate_elc_ephemeral_public_key(cvc: Vec<u8>) -> Result<Vec<u8>, CryptoError> {
     generate_elc_ephemeral_public_key_from_cvc(&cvc).map_err(CryptoError::from)
+}
+
+#[uniffi::export]
+pub fn validate_cvc_chain(
+    chain: Vec<Arc<CvCertificate>>,
+    trust_anchors: Vec<Arc<CvcTrustAnchor>>,
+    validation_time: SystemTime,
+) -> Result<Arc<CvcChainValidationResult>, CryptoError> {
+    let chain = chain.iter().map(|certificate| certificate.as_core().clone()).collect::<Vec<_>>();
+    let trust_anchors = trust_anchors.iter().map(|anchor| anchor.inner.clone()).collect::<Vec<_>>();
+    let inner = core_cvc::validate_cvc_chain(&chain, &trust_anchors, validation_time).map_err(CryptoError::from)?;
+    Ok(Arc::new(CvcChainValidationResult { inner }))
 }
 
 /// Generates a fresh brainpoolP256r1 EC key pair and returns raw key bytes.
@@ -133,6 +191,7 @@ pub fn aes_cmac(key: Vec<u8>, message: Vec<u8>, output_length: i32) -> Result<Ve
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use std::fs;
     use std::path::PathBuf;
 
@@ -152,6 +211,22 @@ mod tests {
         fs::read(&path).expect("fixture should be readable")
     }
 
+    fn load_trust_anchor(name: &str) -> Vec<u8> {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop();
+        path.pop();
+        path.push("test-vectors");
+        path.push("cvc-chain");
+        path.push("pki_cvc_g2_input");
+        path.push("trust-anchor");
+        path.push(name);
+        fs::read(&path).expect("fixture should be readable")
+    }
+
+    fn validation_time(year: i32, month: u32, day: u32) -> SystemTime {
+        chrono::Utc.with_ymd_and_hms(year, month, day, 12, 0, 0).single().unwrap().into()
+    }
+
     #[test]
     fn generate_elc_ephemeral_public_key_exports_public_key_bytes() {
         let cvc_bytes = load_fixture("DEGXX820214.cvc");
@@ -166,6 +241,21 @@ mod tests {
         let result = generate_elc_ephemeral_public_key(Vec::new());
 
         assert!(matches!(result, Err(CryptoError::Asn1Decode { .. })));
+    }
+
+    #[test]
+    fn validate_cvc_chain_accepts_asn1_cvc_objects() {
+        let cvc = openhealth_asn1::ffi::parse_cv_certificate(load_fixture("DEGXX820214.cvc")).unwrap();
+        let anchor = CvcTrustAnchor::from_public_key_tlv(
+            hex_to_bytes("4445475858820214"),
+            load_trust_anchor("4445475858820214_ELC-PublicKey.der"),
+        )
+        .unwrap();
+
+        let result = validate_cvc_chain(vec![cvc], vec![anchor], validation_time(2020, 1, 1)).unwrap();
+
+        assert_eq!(result.validated_certificates(), 1);
+        assert_eq!(hex::encode(result.end_entity_chr()), "4445475858820214");
     }
 
     #[test]

--- a/core-modules/crypto/src/ffi.rs
+++ b/core-modules/crypto/src/ffi.rs
@@ -259,6 +259,15 @@ mod tests {
     }
 
     #[test]
+    fn cvc_trust_anchor_from_certificate_uses_holder_reference() {
+        let cvc = openhealth_asn1::ffi::parse_cv_certificate(load_fixture("DEGXX820214.cvc")).unwrap();
+
+        let anchor = CvcTrustAnchor::from_certificate(cvc).unwrap();
+
+        assert_eq!(hex::encode(anchor.reference()), "4445475858820214");
+    }
+
+    #[test]
     fn brainpool_p256r1_ecdh_matches_for_both_sides() {
         let left = generate_brainpool_p256r1_key_pair().unwrap();
         let right = generate_brainpool_p256r1_key_pair().unwrap();

--- a/core-modules/crypto/src/lib.rs
+++ b/core-modules/crypto/src/lib.rs
@@ -47,6 +47,7 @@ pub mod exchange;
 pub mod ffi;
 
 pub mod cipher;
+pub mod cvc;
 pub mod error;
 pub mod key;
 pub mod mac;

--- a/core-modules/crypto/src/ossl/api.rs
+++ b/core-modules/crypto/src/ossl/api.rs
@@ -148,6 +148,19 @@ pub enum OsslErrorKind {
     #[error("Failed to compute secret")]
     EcdhComputeSecretFailed,
 
+    #[error("Failed to create EVP_MD_CTX")]
+    SignatureDigestCtxCreateFailed,
+    #[error("Failed to create EC public key import context")]
+    EcPublicKeyImportCtxCreateFailed,
+    #[error("Failed to initialize EC public key import")]
+    EcPublicKeyImportInitFailed,
+    #[error("Failed to import EC public key")]
+    EcPublicKeyImportFailed,
+    #[error("Failed to initialize ECDSA verification")]
+    EcdsaVerifyInitFailed,
+    #[error("ECDSA verification failed")]
+    EcdsaVerifyFailed,
+
     #[error("Key initialization failed")]
     MlkemKeyInitFailed,
     #[error("Failed to create context from key")]

--- a/core-modules/crypto/src/ossl/cvc.rs
+++ b/core-modules/crypto/src/ossl/cvc.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright 2026 gematik GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// *******
+//
+// For additional notes and disclaimer from gematik and in case of changes by gematik,
+// find details in the "Readme" file.
+
+use std::ffi::CString;
+use std::ptr;
+
+use crate::ossl::api::{openssl_error, OsslErrorKind, OsslResult};
+use crate::ossl::key::{PKey, PKeyCtx};
+use crypto_openssl_sys::*;
+
+pub struct EcPublicKey(PKey);
+
+impl EcPublicKey {
+    pub fn from_uncompressed(curve_name: &str, public_key: &[u8]) -> OsslResult<Self> {
+        let algorithm = CString::new("EC").expect("static string has no nul");
+        let raw_ctx = unsafe { EVP_PKEY_CTX_new_from_name(ptr::null_mut(), algorithm.as_ptr(), ptr::null()) };
+        if raw_ctx.is_null() {
+            return Err(openssl_error(OsslErrorKind::EcPublicKeyImportCtxCreateFailed));
+        }
+        let import_ctx = PKeyCtx(raw_ctx);
+        if unsafe { EVP_PKEY_fromdata_init(import_ctx.as_ptr()) } != 1 {
+            return Err(openssl_error(OsslErrorKind::EcPublicKeyImportInitFailed));
+        }
+
+        let group = CString::new(curve_name).expect("curve names have no nul");
+        let mut params = [
+            unsafe {
+                OSSL_PARAM_construct_utf8_string(
+                    OSSL_PKEY_PARAM_GROUP_NAME.as_ptr() as *const _,
+                    group.as_ptr() as *mut _,
+                    0,
+                )
+            },
+            unsafe {
+                OSSL_PARAM_construct_octet_string(
+                    OSSL_PKEY_PARAM_PUB_KEY.as_ptr() as *const _,
+                    public_key.as_ptr() as *mut _,
+                    public_key.len(),
+                )
+            },
+            unsafe { OSSL_PARAM_construct_end() },
+        ];
+
+        let mut pkey: *mut EVP_PKEY = ptr::null_mut();
+        if unsafe { EVP_PKEY_fromdata(import_ctx.as_ptr(), &mut pkey, EVP_PKEY_PUBLIC_KEY, params.as_mut_ptr()) } != 1
+            || pkey.is_null()
+        {
+            return Err(openssl_error(OsslErrorKind::EcPublicKeyImportFailed));
+        }
+        Ok(Self(PKey::new(pkey)))
+    }
+}
+
+pub fn verify_ecdsa(
+    public_key: &EcPublicKey,
+    digest_name: &str,
+    message: &[u8],
+    der_signature: &[u8],
+) -> OsslResult<bool> {
+    let md_ctx = unsafe { EVP_MD_CTX_new() };
+    if md_ctx.is_null() {
+        return Err(openssl_error(OsslErrorKind::SignatureDigestCtxCreateFailed));
+    }
+    let digest = CString::new(digest_name).expect("digest names have no nul");
+    let init_result = unsafe {
+        EVP_DigestVerifyInit_ex(
+            md_ctx,
+            ptr::null_mut(),
+            digest.as_ptr(),
+            ptr::null_mut(),
+            ptr::null(),
+            public_key.0.as_mut_ptr(),
+            ptr::null(),
+        )
+    };
+    if init_result != 1 {
+        unsafe { EVP_MD_CTX_free(md_ctx) };
+        return Err(openssl_error(OsslErrorKind::EcdsaVerifyInitFailed));
+    }
+
+    let verify_result = unsafe {
+        EVP_DigestVerify(md_ctx, der_signature.as_ptr(), der_signature.len(), message.as_ptr(), message.len())
+    };
+    unsafe { EVP_MD_CTX_free(md_ctx) };
+    match verify_result {
+        1 => Ok(true),
+        0 => Ok(false),
+        _ => Err(openssl_error(OsslErrorKind::EcdsaVerifyFailed)),
+    }
+}

--- a/core-modules/crypto/src/ossl/mod.rs
+++ b/core-modules/crypto/src/ossl/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod api;
 mod bio;
 pub(crate) mod cipher;
 pub(crate) mod constant_time;
+pub(crate) mod cvc;
 pub(crate) mod digest;
 pub(crate) mod ec;
 mod key;


### PR DESCRIPTION
## Summary
- Add CVC chain validation in the crypto module using parsed ASN.1 `CvCertificate` inputs and `SystemTime` validation dates.
- Preserve ASN.1 source mapping so parsed values can recover their original encoded TLVs, including nested certificate body, public key, and signature spans.
- Use OpenSSL 3 provider/ctx-style APIs for EC public-key import and ECDSA verification, and encode DER signatures through the ASN.1 encoder.

## Testing
- Added unit tests for ASN.1 span capture, restoration after parse errors, and long-form/indefinite length handling.
- Added crypto unit tests for valid and invalid CVC chain validation paths.
- Verified with crate test suites for `asn1` and `crypto`, including `--no-default-features`, plus workspace clippy.