### PR TITLE
OPEN-00: Fix Windows OpenSSL release paths for 4.0.0

### DIFF
--- a/core-modules/crypto-openssl-sys/builder/main.rs
+++ b/core-modules/crypto-openssl-sys/builder/main.rs
@@ -320,7 +320,10 @@ fn ensure_openssl_source(src: &Path, version: &str, repo_url: &str) {
     }
 
     if src.exists() && !has_git {
-        cleanup_dir(src, "source");
+        panic!(
+            "OpenSSL source path '{}' already exists but is not a git checkout; remove it or set OPENSSL_SYS_BUILD_ROOT",
+            src.display()
+        );
     }
 
     if has_git && try_checkout_existing_repo(src, version) {

--- a/core-modules/crypto-openssl-sys/builder/main.rs
+++ b/core-modules/crypto-openssl-sys/builder/main.rs
@@ -69,7 +69,6 @@ struct TargetBuildPaths {
 }
 
 fn target_build_paths(target: &str, openssl_target: &str) -> TargetBuildPaths {
-    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     // Keep paths short (especially on Windows) by avoiding the per-crate hash directory inside `OUT_DIR`.
@@ -84,7 +83,7 @@ fn target_build_paths(target: &str, openssl_target: &str) -> TargetBuildPaths {
         .unwrap_or_else(|| out_dir.ancestors().nth(3).unwrap_or(&out_dir).to_path_buf());
 
     let build_root = build_base.join("openssl").join(target).join(openssl_target);
-    let openssl_src_repo = manifest.join("openssl-src");
+    let openssl_src_repo = build_base.join("openssl-src");
     let build_dir = build_root.join("build");
     let install_dir = build_root.join("install");
 
@@ -316,8 +315,12 @@ fn ensure_openssl_source(src: &Path, version: &str, repo_url: &str) {
     let has_git = src.join(".git").exists();
     let git_matches = has_git && current_git_head(src).map(|rev| rev == version).unwrap_or(false);
 
-    if git_matches || (src.exists() && !has_git) {
+    if git_matches && git_reset_hard(src, version) {
         return;
+    }
+
+    if src.exists() && !has_git {
+        cleanup_dir(src, "source");
     }
 
     if has_git && try_checkout_existing_repo(src, version) {


### PR DESCRIPTION
## Summary
- Move the nested OpenSSL source checkout next to the Cargo build directory so Windows `Configure` sees shorter relative paths.
- Keep the OpenSSL checkout refresh logic working for pinned git revisions while avoiding stale non-git leftovers in the build cache.
- Preserve the existing release build flow and target-specific OpenSSL build/install layout.

## Testing
- `cargo +nightly fmt --check`
- `cargo check -p crypto-openssl-sys --locked`
- Verified the Windows path layout is shorter for the OpenSSL source files that previously hit the edge case.