### PR TITLE
OPEN-00: Fix binding assembly and OpenSSL source handling

### DIFF
--- a/.github/workflows/release-bindings.yml
+++ b/.github/workflows/release-bindings.yml
@@ -451,6 +451,17 @@ jobs:
             assembly/dist/crypto/generated/uniffi/android-jni/**
           if-no-files-found: error
 
+      - name: Stage assembled outputs for Gradle
+        run: |
+          set -euo pipefail
+
+          for module in healthcard asn1 crypto; do
+            dest="core-modules-kotlin/${module}/build/generated/uniffi"
+            rm -rf "${dest}"
+            mkdir -p "${dest}"
+            cp -a "assembly/dist/${module}/generated/uniffi/." "${dest}/"
+          done
+
       - name: Publish Kotlin bindings to mavenLocal (assembled outputs)
         run: |
           if [ -n "${{ inputs.version }}" ]; then
@@ -459,12 +470,10 @@ jobs:
 
           cd core-modules-kotlin
 
-          OUT_ROOT="${GITHUB_WORKSPACE}/assembly/dist/healthcard/generated/uniffi" \
-            ./gradlew --no-daemon :healthcard:publishToMavenLocal
-          OUT_ROOT="${GITHUB_WORKSPACE}/assembly/dist/asn1/generated/uniffi" \
-            ./gradlew --no-daemon :asn1:publishToMavenLocal
-          OUT_ROOT="${GITHUB_WORKSPACE}/assembly/dist/crypto/generated/uniffi" \
-            ./gradlew --no-daemon :crypto:publishToMavenLocal
+          ./gradlew --no-daemon \
+            :healthcard:publishToMavenLocal \
+            :asn1:publishToMavenLocal \
+            :crypto:publishToMavenLocal
 
       - name: Stage Maven local artifacts for upload
         run: |

--- a/core-modules/crypto-openssl-sys/builder/main.rs
+++ b/core-modules/crypto-openssl-sys/builder/main.rs
@@ -320,7 +320,10 @@ fn ensure_openssl_source(src: &Path, version: &str, repo_url: &str) {
     }
 
     if src.exists() && !has_git {
-        cleanup_dir(src, "source");
+        panic!(
+            "OpenSSL source path '{}' already exists but is not a git checkout; remove it or set OPENSSL_SYS_BUILD_ROOT",
+            src.display()
+        );
     }
 
     if has_git && try_checkout_existing_repo(src, version) {

--- a/core-modules/crypto-openssl-sys/builder/main.rs
+++ b/core-modules/crypto-openssl-sys/builder/main.rs
@@ -69,7 +69,6 @@ struct TargetBuildPaths {
 }
 
 fn target_build_paths(target: &str, openssl_target: &str) -> TargetBuildPaths {
-    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     // Keep paths short (especially on Windows) by avoiding the per-crate hash directory inside `OUT_DIR`.
@@ -84,7 +83,7 @@ fn target_build_paths(target: &str, openssl_target: &str) -> TargetBuildPaths {
         .unwrap_or_else(|| out_dir.ancestors().nth(3).unwrap_or(&out_dir).to_path_buf());
 
     let build_root = build_base.join("openssl").join(target).join(openssl_target);
-    let openssl_src_repo = manifest.join("openssl-src");
+    let openssl_src_repo = build_base.join("openssl-src");
     let build_dir = build_root.join("build");
     let install_dir = build_root.join("install");
 
@@ -316,8 +315,12 @@ fn ensure_openssl_source(src: &Path, version: &str, repo_url: &str) {
     let has_git = src.join(".git").exists();
     let git_matches = has_git && current_git_head(src).map(|rev| rev == version).unwrap_or(false);
 
-    if git_matches || (src.exists() && !has_git) {
+    if git_matches && git_reset_hard(src, version) {
         return;
+    }
+
+    if src.exists() && !has_git {
+        cleanup_dir(src, "source");
     }
 
     if has_git && try_checkout_existing_repo(src, version) {


### PR DESCRIPTION
## Changes
- Stage assembled Kotlin binding outputs into each module-specific Gradle generated directory before publication.
- Publish the Kotlin binding modules in one Gradle invocation without a process-wide `OUT_ROOT`, so dependent subprojects compile against their own generated sources.

## Breaking Changes
- None

## Checklist
- [ ] Tests added/updated where appropriate
- [x] FFI targets (swift, kotlin, ...) are updated where appropriate
- [ ] Public API is documented
- [ ] Docs updated (`docs/`, `README.md`) if needed
- [ ] Release notes updated (`ReleaseNotes.md`) if user-facing change

## Testing
- `git diff --check`
- Not run: full GitHub Actions binding release workflow locally